### PR TITLE
Added ColorMode RGBA for GridMap

### DIFF
--- a/include/glk/gridmap.hpp
+++ b/include/glk/gridmap.hpp
@@ -14,6 +14,7 @@ public:
 
   GridMap(double resolution, int width, int height, const unsigned char* values, int alpha = 255, ColorMode mode = ColorMode::PROB);
   GridMap(double resolution, int width, int height, float scale, const float* values, float alpha = 1.0f, ColorMode mode = ColorMode::PROB);
+  GridMap(double resolution, int width, int height, const unsigned char* values, bool tmp);   // Added bool to avoid ambiguity
   virtual ~GridMap();
 
   virtual void draw(glk::GLSLShader& shader) const override;

--- a/include/glk/gridmap.hpp
+++ b/include/glk/gridmap.hpp
@@ -10,11 +10,10 @@ class Texture;
 
 class GridMap : public Drawable {
 public:
-  enum class ColorMode { RAW = 0, TURBO, PROB, PROB_TURBO };
+  enum class ColorMode { RAW = 0, TURBO, PROB, PROB_TURBO, RGBA };
 
   GridMap(double resolution, int width, int height, const unsigned char* values, int alpha = 255, ColorMode mode = ColorMode::PROB);
   GridMap(double resolution, int width, int height, float scale, const float* values, float alpha = 1.0f, ColorMode mode = ColorMode::PROB);
-  GridMap(double resolution, int width, int height, const unsigned char* values, bool tmp);   // Added bool to avoid ambiguity
   virtual ~GridMap();
 
   virtual void draw(glk::GLSLShader& shader) const override;

--- a/src/example/ext_light_viewer_gridmap.cpp
+++ b/src/example/ext_light_viewer_gridmap.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  auto grid_map_free = std::make_shared<glk::GridMap>(resolution, width, height, color_map_free.data(), true);
+  auto grid_map_free = std::make_shared<glk::GridMap>(resolution, width, height, color_map_free.data(), 255, glk::GridMap::ColorMode::RGBA);
   viewer->update_drawable("gridmap_free", grid_map_free, guik::TextureColor());
 
   std::vector<unsigned char> color_map_turbo(height * width);

--- a/src/example/ext_light_viewer_gridmap.cpp
+++ b/src/example/ext_light_viewer_gridmap.cpp
@@ -10,7 +10,7 @@ int main(int argc, char** argv) {
   int width = 100, height = 100;
   double resolution = 0.1;
 
-  std::vector<unsigned char> color_map_free(height * width * 4);
+  std::vector<unsigned char> color_map_rgba(height * width * 4);
   unsigned char r, g, b, a;
   b = 0;
   a = 255;
@@ -20,15 +20,15 @@ int main(int argc, char** argv) {
       g = j * (255 / (double)width);
       
       int idx = (i * width + j) * 4;
-      color_map_free[idx + 0] = r;
-      color_map_free[idx + 1] = g;
-      color_map_free[idx + 2] = b;
-      color_map_free[idx + 3] = a;
+      color_map_rgba[idx + 0] = r;
+      color_map_rgba[idx + 1] = g;
+      color_map_rgba[idx + 2] = b;
+      color_map_rgba[idx + 3] = a;
     }
   }
 
-  auto grid_map_free = std::make_shared<glk::GridMap>(resolution, width, height, color_map_free.data(), 255, glk::GridMap::ColorMode::RGBA);
-  viewer->update_drawable("gridmap_free", grid_map_free, guik::TextureColor());
+  auto grid_map_rgba = std::make_shared<glk::GridMap>(resolution, width, height, color_map_rgba.data(), 255, glk::GridMap::ColorMode::RGBA);
+  viewer->update_drawable("gridmap_rgba", grid_map_rgba, guik::TextureColor());
 
   std::vector<unsigned char> color_map_turbo(height * width);
   for (int i = 0; i < height; i++) {
@@ -42,11 +42,11 @@ int main(int argc, char** argv) {
 
   int color_map_type = 0;
   viewer->register_ui_callback("colormap_selector", [&]() {
-    ImGui::Combo("ColorMap", &color_map_type, "FREE\0TURBO\0\0");
+    ImGui::Combo("ColorMap", &color_map_type, "RGBA\0TURBO\0\0");
   });
 
   viewer->register_drawable_filter("drawable_filter", [&](const std::string& drawable_name){
-    if (color_map_type != 0 && drawable_name.find("gridmap_free") != std::string::npos)
+    if (color_map_type != 0 && drawable_name.find("gridmap_rgba") != std::string::npos)
       return false;
     if (color_map_type != 1 && drawable_name.find("gridmap_turbo") != std::string::npos)
       return false;

--- a/src/example/ext_light_viewer_gridmap.cpp
+++ b/src/example/ext_light_viewer_gridmap.cpp
@@ -1,0 +1,60 @@
+#include <iostream>
+
+#include <glk/gridmap.hpp>
+
+#include <guik/viewer/light_viewer.hpp>
+
+int main(int argc, char** argv) {
+  auto viewer = guik::LightViewer::instance();
+
+  int width = 100, height = 100;
+  double resolution = 0.1;
+
+  std::vector<unsigned char> color_map_free(height * width * 4);
+  unsigned char r, g, b, a;
+  b = 0;
+  a = 255;
+  for (int i = 0; i < height; i++) {
+    r = i * (255 / (double)height);
+    for (int j = 0; j < width; j++) {
+      g = j * (255 / (double)width);
+      
+      int idx = (i * width + j) * 4;
+      color_map_free[idx + 0] = r;
+      color_map_free[idx + 1] = g;
+      color_map_free[idx + 2] = b;
+      color_map_free[idx + 3] = a;
+    }
+  }
+
+  auto grid_map_free = std::make_shared<glk::GridMap>(resolution, width, height, color_map_free.data(), true);
+  viewer->update_drawable("gridmap_free", grid_map_free, guik::TextureColor());
+
+  std::vector<unsigned char> color_map_turbo(height * width);
+  for (int i = 0; i < height; i++) {
+    for (int j = 0; j < width; j++) {
+      color_map_turbo[i * width + j] = i + j;
+    }
+  }
+  
+  auto grid_map = std::make_shared<glk::GridMap>(resolution, width, height, color_map_turbo.data(), 255, glk::GridMap::ColorMode::TURBO);
+  viewer->update_drawable("gridmap_turbo", grid_map, guik::TextureColor());
+
+  int color_map_type = 0;
+  viewer->register_ui_callback("colormap_selector", [&]() {
+    ImGui::Combo("ColorMap", &color_map_type, "FREE\0TURBO\0\0");
+  });
+
+  viewer->register_drawable_filter("drawable_filter", [&](const std::string& drawable_name){
+    if (color_map_type != 0 && drawable_name.find("gridmap_free") != std::string::npos)
+      return false;
+    if (color_map_type != 1 && drawable_name.find("gridmap_turbo") != std::string::npos)
+      return false;
+
+    return true;
+  });
+
+  viewer->spin();
+
+  return 0;
+}

--- a/src/glk/gridmap.cpp
+++ b/src/glk/gridmap.cpp
@@ -23,8 +23,12 @@ GridMap::GridMap(double resolution, int width, int height, const unsigned char* 
       case ColorMode::PROB_TURBO:
         rgb = glk::colormap(glk::COLORMAP::TURBO, (100 - x) * 255.0 / 100.0).cast<unsigned char>().head<3>();
         break;
+      case ColorMode::RGBA:
+        std::copy(values + i * 4, values + i * 4 + 3, rgba.begin() + i * 4);
+        break;
     }
-    rgba[i * 4 + 3] = alpha;
+    if (mode != ColorMode::RGBA)
+      rgba[i * 4 + 3] = alpha;
   }
 
   texture.reset(new Texture(Eigen::Vector2i(width, height), GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, rgba.data()));
@@ -60,18 +64,6 @@ GridMap::GridMap(double resolution, int width, int height, float scale, const fl
   }
 
   texture.reset(new Texture(Eigen::Vector2i(width, height), GL_RGBA, GL_RGBA, GL_FLOAT, rgba.data()));
-  texture->bind();
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-  texture->unbind();
-
-  init_vao(resolution, width, height);
-}
-
-GridMap::GridMap(double resolution, int width, int height, const unsigned char* values, bool tmp) {
-  std::vector<unsigned char> rgba(values, values + (width * height * 4));
-
-  texture.reset(new Texture(Eigen::Vector2i(width, height), GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, rgba.data()));
   texture->bind();
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/src/glk/gridmap.cpp
+++ b/src/glk/gridmap.cpp
@@ -24,7 +24,7 @@ GridMap::GridMap(double resolution, int width, int height, const unsigned char* 
         rgb = glk::colormap(glk::COLORMAP::TURBO, (100 - x) * 255.0 / 100.0).cast<unsigned char>().head<3>();
         break;
       case ColorMode::RGBA:
-        std::copy(values + i * 4, values + i * 4 + 3, rgba.begin() + i * 4);
+        std::copy(values + i * 4, values + i * 4 + 4, rgba.begin() + i * 4);
         break;
     }
     if (mode != ColorMode::RGBA)

--- a/src/glk/gridmap.cpp
+++ b/src/glk/gridmap.cpp
@@ -68,6 +68,18 @@ GridMap::GridMap(double resolution, int width, int height, float scale, const fl
   init_vao(resolution, width, height);
 }
 
+GridMap::GridMap(double resolution, int width, int height, const unsigned char* values, bool tmp) {
+  std::vector<unsigned char> rgba(values, values + (width * height * 4));
+
+  texture.reset(new Texture(Eigen::Vector2i(width, height), GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, rgba.data()));
+  texture->bind();
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  texture->unbind();
+
+  init_vao(resolution, width, height);
+}
+
 GridMap::~GridMap() {
   glDeleteBuffers(1, &vao);
   glDeleteBuffers(1, &vbo);


### PR DESCRIPTION
# Description
* Added new ColorMode `RGBA` for GridMap to allow user to set RGBA independently
* Added a small example for GridMap

![gridmap](https://user-images.githubusercontent.com/36657833/217978731-5cbca6ef-8050-49bf-ba4f-29b57b543adb.gif)

# Step to Test
* Run ext_light_viewer_gridmap