### PR TITLE
fix docker permissions: mount `/dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ cd ..
 sudo python3 setup.py install
 ```
 
+### Docker
+
+* Build: `docker build -t iridescence -f docker/ubuntu/Dockerfile .`
+* Run: `bash docker/run.sh iridescence`
+
 ## Use Iridescence in your cmake project
 
 ```bash

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -5,7 +5,7 @@ sudo docker run -it --rm \
 			--gpus all \
 			-e DISPLAY=$DISPLAY \
 			-v /tmp/.X11-unix:/tmp/.X11-unix \
-            -v /dev:/dev \
+                        -v /dev:/dev \
 			$@
 
 # xhost - local:root

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -5,6 +5,7 @@ sudo docker run -it --rm \
 			--gpus all \
 			-e DISPLAY=$DISPLAY \
 			-v /tmp/.X11-unix:/tmp/.X11-unix \
+            -v /dev:/dev \
 			$@
 
 # xhost - local:root

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,11 @@ cd ..
 sudo python3 setup.py install
 ```
 
+### Docker
+
+* Build: `docker build -t iridescence -f docker/ubuntu/Dockerfile .`
+* Run: `bash docker/run.sh iridescence`
+
 ## Use Iridescence in your cmake project
 
 ```bash


### PR DESCRIPTION
Thanks for providing this great repository!

Running the default docker script, I am encountering this error:

```
MESA: error: Failed to query drm device.
libGL error: glx: failed to create dri3 screen
libGL error: failed to load driver: iris
libGL error: failed to open /dev/dri/card0: No such file or directory
libGL error: failed to load driver: iris
X Error of failed request:  BadShmSeg (invalid shared segment parameter)
  Major opcode of failed request:  130 (MIT-SHM)
  Minor opcode of failed request:  3 (X_ShmPutImage)
  Segment id in failed request:  0x4200007
  Serial number of failed request:  136
  Current serial number in output stream:  137
```


This PR
* fixes docker permissions by mounting `/dev`
* Add docker documentation

On a related note: How would you compare rviz vs iridescence visualization performance for large maps? 