### PR TITLE
Added zenity install

### DIFF
--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get install -y --no-install-recommends wget nano build-essential cmake git clang lld \
   libpng-dev libjpeg-dev libeigen3-dev libboost-all-dev libglm-dev libglfw3-dev ca-certificates \
-  libfmt-dev libspdlog-dev libassimp-dev \
+  libfmt-dev libspdlog-dev libassimp-dev zenity \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/ubuntu_llvm/Dockerfile
+++ b/docker/ubuntu_llvm/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get install -y --no-install-recommends wget nano build-essential cmake git clang lld \
   libpng-dev libjpeg-dev libeigen3-dev libboost-all-dev libglm-dev libglfw3-dev ca-certificates \
-  libfmt-dev libspdlog-dev libassimp-dev \
+  libfmt-dev libspdlog-dev libassimp-dev zenity \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I had the same problem as mentioned in https://github.com/koide3/iridescence/issues/52 before. This PR fixes that issue by adding Zenity installation in Dockerfiles.

A little bit of background. It seems like [portable-file-dialogs](https://github.com/samhocevar/portable-file-dialogs) looks for Zenity (or KDE Kdialog) if it's used on Linux, as you can see [here](https://github.com/samhocevar/portable-file-dialogs/blob/ece1202552b887bb2dc72d0364f5b2069639e53c/portable-file-dialogs.h#L465). If you compile this project locally, there would be no problem as Zenity is installed with the desktop version (assuming Ubuntu) by default. However, Zenity doesn't seem to be included in the base image.