### PR TITLE
[wip] Fix examples

### DIFF
--- a/include/glk/mesh_utils.hpp
+++ b/include/glk/mesh_utils.hpp
@@ -13,14 +13,14 @@ public:
     vertices.resize(indices_.size());
     normals.resize(indices_.size());
     indices.resize(indices_.size());
-    for (int i = 0; i < indices_.size(); i += 3) {
+    for (size_t i = 0; i < indices_.size(); i += 3) {
       Eigen::Vector3f v1 = vertices_[indices_[i]];
       Eigen::Vector3f v2 = vertices_[indices_[i + 1]];
       Eigen::Vector3f v3 = vertices_[indices_[i + 2]];
 
       Eigen::Vector3f n = (v2 - v1).cross(v3 - v2);
 
-      for (int j = 0; j < 3; j++) {
+      for (size_t j = 0; j < 3; j++) {
         vertices[i + j] = vertices_[indices_[i + j]];
         normals[i + j] = n;
         indices[i + j] = i + j;
@@ -38,7 +38,7 @@ class NormalEstimater {
 public:
   NormalEstimater(const std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>>& vertices, const std::vector<int>& indices) {
     normals.resize(vertices.size(), Eigen::Vector3f::Zero());
-    for (int i = 0; i < indices.size(); i += 3) {
+    for (size_t i = 0; i < indices.size(); i += 3) {
       Eigen::Vector3f v1 = vertices[indices[i]];
       Eigen::Vector3f v2 = vertices[indices[i + 1]];
       Eigen::Vector3f v3 = vertices[indices[i + 2]];

--- a/include/glk/pointcloud_buffer_pcl.hpp
+++ b/include/glk/pointcloud_buffer_pcl.hpp
@@ -11,7 +11,7 @@ namespace glk {
 template<typename PointT>
 std::shared_ptr<PointCloudBuffer> create_point_cloud_buffer(const pcl::PointCloud<PointT>& cloud) {
   std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> points(cloud.size());
-  for(int i = 0; i < cloud.size(); i++) {
+  for(size_t i = 0; i < cloud.size(); i++) {
     points[i] = cloud[i].getVector3fMap();
   }
   return std::make_shared<PointCloudBuffer>(points[0].data(), sizeof(Eigen::Vector3f), cloud.size());
@@ -26,7 +26,7 @@ template<>
 inline std::shared_ptr<PointCloudBuffer> create_point_cloud_buffer(const pcl::PointCloud<pcl::PointNormal>& cloud) {
   std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> points(cloud.size());
   std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> normals(cloud.size());
-  for(int i = 0; i < cloud.size(); i++) {
+  for(size_t i = 0; i < cloud.size(); i++) {
     points[i] = cloud[i].getVector3fMap();
     normals[i] = cloud[i].getNormalVector3fMap();
   }
@@ -42,7 +42,7 @@ std::shared_ptr<PointCloudBuffer> create_colored_point_cloud_buffer(const pcl::P
   std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> points(cloud.size());
   std::vector<Eigen::Vector4f, Eigen::aligned_allocator<Eigen::Vector4f>> colors(cloud.size());
 
-  for(int i = 0; i < cloud.size(); i++) {
+  for(size_t i = 0; i < cloud.size(); i++) {
     points[i] = cloud[i].getVector3fMap();
     colors[i] = Eigen::Vector4f(cloud[i].r, cloud[i].g, cloud[i].b, cloud[i].a) / 255.0f;
   }

--- a/include/glk/primitives/cone.hpp
+++ b/include/glk/primitives/cone.hpp
@@ -14,7 +14,7 @@ public:
     vertices.push_back(Eigen::Vector3f::UnitZ());
 
     double step = 2.0 * M_PI / div;
-    for(int i = 0; i < div; i++) {
+    for(size_t i = 0; i < div; i++) {
       double rad = step * i;
       vertices.push_back(Eigen::Vector3f(std::cos(rad), std::sin(rad), 0.0f));
 

--- a/include/glk/primitives/cube.hpp
+++ b/include/glk/primitives/cube.hpp
@@ -29,7 +29,7 @@ public:
     };
 
     std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> normals(vertices.size());
-    for (int i = 0; i < vertices.size(); i++) {
+    for (size_t i = 0; i < vertices.size(); i++) {
       normals[i] = vertices[i].normalized();
     }
 

--- a/include/glk/primitives/frustum.hpp
+++ b/include/glk/primitives/frustum.hpp
@@ -20,7 +20,7 @@ public:
     normals.push_back(Eigen::Vector3f(0, 0, 1));
     normals.push_back(Eigen::Vector3f(0, 0, 1));
 
-    for(int i = 0; i < 4; i++) {
+    for(size_t i = 0; i < 4; i++) {
       indices.push_back(i);
       indices.push_back((i + 1) % 4);
 

--- a/include/glk/primitives/icosahedron.hpp
+++ b/include/glk/primitives/icosahedron.hpp
@@ -18,7 +18,7 @@ public:
         Eigen::Vector3f(t, 0, -1), Eigen::Vector3f(t, 0, 1), Eigen::Vector3f(-t, 0, -1), Eigen::Vector3f(-t, 0, 1)};
 
     std::vector<Eigen::Vector3f, Eigen::aligned_allocator<Eigen::Vector3f>> normals(vertices.size());
-    for(int i = 0; i < vertices.size(); i++) {
+    for(size_t i = 0; i < vertices.size(); i++) {
       normals[i] = vertices[i].normalized();
     }
 
@@ -33,7 +33,7 @@ public:
 
   void subdivide() {
     std::vector<int> new_indices;
-    for(int i = 0; i < indices.size(); i += 3) {
+    for(size_t i = 0; i < indices.size(); i += 3) {
       int a = insert_middle_point(indices[i], indices[i + 1]);
       int b = insert_middle_point(indices[i + 1], indices[i + 2]);
       int c = insert_middle_point(indices[i + 2], indices[i]);
@@ -46,7 +46,7 @@ public:
     indices.swap(new_indices);
 
     normals.resize(vertices.size());
-    for(int i = 0; i < vertices.size(); i++) {
+    for(size_t i = 0; i < vertices.size(); i++) {
       normals[i] = vertices[i].normalized();
     }
   }
@@ -57,7 +57,7 @@ public:
     }
 
     normals.resize(vertices.size());
-    for(int i = 0; i < vertices.size(); i++) {
+    for(size_t i = 0; i < vertices.size(); i++) {
       normals[i] = vertices[i].normalized();
     }
   }

--- a/include/glk/profiler.hpp
+++ b/include/glk/profiler.hpp
@@ -43,7 +43,7 @@ public:
     std::string label_format = "\%-" + std::to_string(max_name_length) + "s";
 
     double sum_time_msec = 0.0;
-    for(int i = 0; i < labels.size(); i++) {
+    for(size_t i = 0; i < labels.size(); i++) {
       int result = 0;
       glGetQueryObjectiv(queries[i], GL_QUERY_RESULT, &result);
       double time_msec = result / 1e6;
@@ -109,7 +109,7 @@ public:
     }
     std::string label_format = "\%-" + std::to_string(max_name_length) + "s";
 
-    for(int i = 0; i < labels.size() - 1; i++) {
+    for(size_t i = 0; i < labels.size() - 1; i++) {
       double time_msec = std::chrono::duration_cast<std::chrono::nanoseconds>(times[i + 1] - times[i]).count() / 1e6;
       double sum_time_msec = std::chrono::duration_cast<std::chrono::nanoseconds>(times[i + 1] - times.front()).count() / 1e6;
       std::cout << boost::format(label_format) % labels[i] << boost::format(":%.3f[msec] (%.3f[msec])") % time_msec % sum_time_msec << std::endl;
@@ -170,7 +170,7 @@ public:
     std::string label_format = "\%-" + std::to_string(max_name_length) + "s";
 
     double sum_time_msec_gl = 0.0;
-    for(int i = 0; i < labels.size(); i++) {
+    for(size_t i = 0; i < labels.size(); i++) {
       int result = 0;
       glGetQueryObjectiv(queries[i], GL_QUERY_RESULT, &result);
       double time_msec_gl = result / 1e6;

--- a/include/glk/type_conversion.hpp
+++ b/include/glk/type_conversion.hpp
@@ -47,7 +47,7 @@ std::vector<Eigen::Matrix<Dst_Scalar, Dst_Rows, Dst_Cols>, Allocator<Eigen::Matr
   constexpr int Cols = std::min(Dst_Cols, Src_Cols);
 
   std::vector<Eigen::Matrix<Dst_Scalar, Dst_Rows, Dst_Cols>, Allocator<Eigen::Matrix<Dst_Scalar, Dst_Rows, Dst_Cols>>> converted(num_points);
-  for (int i = 0; i < num_points; i++) {
+  for (size_t i = 0; i < num_points; i++) {
     converted[i].template block<Rows, Cols>(0, 0) = points[i].template cast<Dst_Scalar>().template block<Rows, Cols>(0, 0);
   }
   return converted;

--- a/include/guik/gl_canvas.hpp
+++ b/include/guik/gl_canvas.hpp
@@ -18,7 +18,7 @@ class GLCanvas {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  GLCanvas(const Eigen::Vector2i& size, const std::string& shader_name = "rainbow");
+  GLCanvas(const Eigen::Vector2i& size, const std::string& shader_name = "rainbow", size_t num_color_buffers = 1);
 
   bool ready() const;
   bool load_shader(const std::string& shader_name);

--- a/src/example/gl_test_field_example.cpp
+++ b/src/example/gl_test_field_example.cpp
@@ -21,7 +21,7 @@ public:
   virtual bool init(const Eigen::Vector2i& size, const char* glsl_version, bool background = false) override {
     Application::init(size, glsl_version);
 
-    main_canvas.reset(new guik::GLCanvas(size, "phong"));
+    main_canvas.reset(new guik::GLCanvas(size, "phong", 3));
     if(!main_canvas->ready()) {
       close();
       return false;

--- a/src/glk/frame_buffer.cpp
+++ b/src/glk/frame_buffer.cpp
@@ -67,21 +67,23 @@ Eigen::Vector2i FrameBuffer::size() const {
 }
 
 const Texture& FrameBuffer::color() const {
-  return *color_buffers[0];
+  return *color_buffers.at(0);
 }
+
 const Texture& FrameBuffer::color(int i) const {
-  return *color_buffers[i];
+  return *color_buffers.at(i);
 }
+
 const Texture& FrameBuffer::depth() const {
   return *depth_buffer;
 }
 
 Texture& FrameBuffer::color() {
-  return *color_buffers[0];
+    return *color_buffers.at(0);
 }
 
 Texture& FrameBuffer::color(int i) {
-  return *color_buffers[i];
+  return *color_buffers.at(i);
 }
 
 Texture& FrameBuffer::depth() {

--- a/src/guik/gl_canvas.cpp
+++ b/src/guik/gl_canvas.cpp
@@ -32,8 +32,8 @@ using namespace glk::console;
  *
  * @param size
  */
-GLCanvas::GLCanvas(const Eigen::Vector2i& size, const std::string& shader_name) : size(size), clear_color(0.27f, 0.27f, 0.27f, 1.0f) {
-  frame_buffer.reset(new glk::FrameBuffer(size, 1));
+GLCanvas::GLCanvas(const Eigen::Vector2i& size, const std::string& shader_name, size_t num_color_buffers) : size(size), clear_color(0.27f, 0.27f, 0.27f, 1.0f) {
+  frame_buffer.reset(new glk::FrameBuffer(size, num_color_buffers));
   shader.reset(new glk::GLSLShader());
   if (!shader->init(glk::get_data_path() + "/shader/" + shader_name)) {
     shader.reset();


### PR DESCRIPTION
This PR:

* fixes `example/ext_light_viewer_capture.cpp` and `example/ext_light_viewer_effects.cpp` segfault by wrapping the call to `nvidia-smi` in a try/catch block. This effectively makes these examples work on non-GPU systems.
* fixes `example/gl_test_field_example.cpp` by correctly (?) initializing the number of color buffers in `gl_canvas`. Please let me know if my thinking is correct here.
* removes some implicit conversions found with `-Wall`

Remaining Issues:
* Rendered text in `/ext_light_viewer_effects.cpp` and `example/ext_light_viewer_capture.cpp` is mangled/mixed like this
![issue#1](https://github.com/koide3/iridescence/assets/22290570/8980d8e4-2f93-496c-a6f2-aab0ca66e918)
* Bunny primitive selection in `example/gl_test_field_example.cpp` loads empty texture with warning: `warning: attrib vert_color not found`, even when correcting this typo:

  ```cpp
        const char* items[] = {.... "BUNNYY"};
        --> const char* items[] = {.... "BUNNY"};
  ```
  