### PR TITLE
Fix gl test field example

### DIFF
--- a/include/guik/gl_canvas.hpp
+++ b/include/guik/gl_canvas.hpp
@@ -18,7 +18,7 @@ class GLCanvas {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  GLCanvas(const Eigen::Vector2i& size, const std::string& shader_name = "rainbow");
+  GLCanvas(const Eigen::Vector2i& size, const std::string& shader_name = "rainbow", size_t num_color_buffers = 1);
 
   bool ready() const;
   bool load_shader(const std::string& shader_name);

--- a/src/example/gl_test_field_example.cpp
+++ b/src/example/gl_test_field_example.cpp
@@ -53,7 +53,7 @@ public:
       ImGui::Combo("type", &primitive_type_combo, items, IM_ARRAYSIZE(items));
 
       // because COORDINATE_SYSTEM falls through to SOLID_COORDINATE_SYSTEM in Primitives::create_primitive,
-      //increment bunny toggle from gui (in items) by one if primitive type is 5 (COORDINATE_SYSTEM)
+      //increment bunny toggle from gui (in items) by one if primitive type is 6 (COORDINATE_SYSTEM)
       primitive_type_render = (primitive_type_combo == 6) ? primitive_type_combo + 1 : primitive_type_combo;
 
       ImGui::End();

--- a/src/example/gl_test_field_example.cpp
+++ b/src/example/gl_test_field_example.cpp
@@ -22,12 +22,11 @@ public:
     Application::init(size, glsl_version);
 
     main_canvas.reset(new guik::GLCanvas(size, "phong", 3));
-    if(!main_canvas->ready()) {
+    if (!main_canvas->ready()) {
       close();
       return false;
     }
 
-    primitive_type = 0;
     model_control.reset(new guik::ModelControl("cube"));
 
     return true;
@@ -38,9 +37,9 @@ public:
    */
   virtual void draw_ui() override {
     // main menu
-    if(ImGui::BeginMainMenuBar()) {
-      if(ImGui::BeginMenu("File")) {
-        if(ImGui::MenuItem("Quit")) {
+    if (ImGui::BeginMainMenuBar()) {
+      if (ImGui::BeginMenu("File")) {
+        if (ImGui::MenuItem("Quit")) {
           close();
         }
         ImGui::EndMenu();
@@ -49,9 +48,14 @@ public:
     }
 
     {
-      const char* items[] = {"ICOSAHEDRON", "SPHERE", "CUBE", "CONE", "GRID", "COORDINATE_SYSTEM", "BUNNYY"};
+      const char* items[] = {"ICOSAHEDRON", "SPHERE", "CUBE", "CONE", "GRID", "COORDINATE_SYSTEM", "BUNNY"};
       ImGui::Begin("primitive", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
-      ImGui::Combo("type", &primitive_type, items, IM_ARRAYSIZE(items));
+      ImGui::Combo("type", &primitive_type_combo, items, IM_ARRAYSIZE(items));
+
+      // because COORDINATE_SYSTEM falls through to SOLID_COORDINATE_SYSTEM in Primitives::create_primitive,
+      //increment bunny toggle from gui (in items) by one if primitive type is 5 (COORDINATE_SYSTEM)
+      primitive_type_render = (primitive_type_combo == 6) ? primitive_type_combo + 1 : primitive_type_combo;
+
       ImGui::End();
     }
 
@@ -74,7 +78,7 @@ public:
     model_control->draw_gizmo(0, 0, 1920, 1080, view_matrix, projection_matrix);
 
     // mouse control
-    if(!ImGui::GetIO().WantCaptureMouse && !ImGuizmo::IsUsing()) {
+    if (!ImGui::GetIO().WantCaptureMouse && !ImGuizmo::IsUsing()) {
       main_canvas->mouse_control();
     }
   }
@@ -107,14 +111,15 @@ public:
     main_canvas->shader->set_uniform("material_emission", Eigen::Vector4f(0.0f, 0.0f, 0.0f, 1.0f));
 
     main_canvas->shader->set_uniform("model_matrix", model_control->model_matrix());
-    glk::Primitives::primitive(static_cast<glk::Primitives::PrimitiveType>(primitive_type)).draw(*main_canvas->shader);
+    glk::Primitives::primitive(static_cast<glk::Primitives::PrimitiveType>(primitive_type_render)).draw(*main_canvas->shader);
 
     main_canvas->unbind();
     main_canvas->render_to_screen();
   }
 
 private:
-  int primitive_type;
+  int primitive_type_combo = 0;
+  int primitive_type_render = 0;
   std::unique_ptr<guik::GLCanvas> main_canvas;
   std::unique_ptr<guik::ModelControl> model_control;
 };
@@ -122,7 +127,7 @@ private:
 int main(int argc, char** argv) {
   std::unique_ptr<guik::Application> app(new GLTestField());
 
-  if(!app->init(Eigen::Vector2i(1920, 1080), "#version 330")) {
+  if (!app->init(Eigen::Vector2i(1920, 1080), "#version 330")) {
     return 1;
   }
 

--- a/src/example/gl_test_field_example.cpp
+++ b/src/example/gl_test_field_example.cpp
@@ -21,7 +21,7 @@ public:
   virtual bool init(const Eigen::Vector2i& size, const char* glsl_version, bool background = false) override {
     Application::init(size, glsl_version);
 
-    main_canvas.reset(new guik::GLCanvas(size, "phong"));
+    main_canvas.reset(new guik::GLCanvas(size, "phong", 3));
     if(!main_canvas->ready()) {
       close();
       return false;

--- a/src/glk/frame_buffer.cpp
+++ b/src/glk/frame_buffer.cpp
@@ -67,21 +67,23 @@ Eigen::Vector2i FrameBuffer::size() const {
 }
 
 const Texture& FrameBuffer::color() const {
-  return *color_buffers[0];
+  return *color_buffers.at(0);
 }
+
 const Texture& FrameBuffer::color(int i) const {
-  return *color_buffers[i];
+  return *color_buffers.at(i);
 }
+
 const Texture& FrameBuffer::depth() const {
   return *depth_buffer;
 }
 
 Texture& FrameBuffer::color() {
-  return *color_buffers[0];
+    return *color_buffers.at(0);
 }
 
 Texture& FrameBuffer::color(int i) {
-  return *color_buffers[i];
+  return *color_buffers.at(i);
 }
 
 Texture& FrameBuffer::depth() {

--- a/src/glk/primitives/primitives.cpp
+++ b/src/glk/primitives/primitives.cpp
@@ -76,7 +76,7 @@ const glk::Drawable& Primitives::create_primitive(PrimitiveType type) {
         meshes[type].reset(new glk::Lines(0.01f, coord.vertices, coord.colors));
       } break;
       case WIRE_FRUSTUM: {
-        glk::Frustum frustum(0.6f, 0.4f, 0.5f);
+          glk::Frustum frustum(0.6f, 0.4f, 0.5f);
         meshes[type].reset(new glk::Mesh(frustum.vertices, frustum.normals, frustum.indices, true));
       } break;
     }

--- a/src/guik/gl_canvas.cpp
+++ b/src/guik/gl_canvas.cpp
@@ -32,8 +32,8 @@ using namespace glk::console;
  *
  * @param size
  */
-GLCanvas::GLCanvas(const Eigen::Vector2i& size, const std::string& shader_name) : size(size), clear_color(0.27f, 0.27f, 0.27f, 1.0f) {
-  frame_buffer.reset(new glk::FrameBuffer(size, 1));
+GLCanvas::GLCanvas(const Eigen::Vector2i& size, const std::string& shader_name, size_t num_color_buffers) : size(size), clear_color(0.27f, 0.27f, 0.27f, 1.0f) {
+  frame_buffer.reset(new glk::FrameBuffer(size, num_color_buffers));
   shader.reset(new glk::GLSLShader());
   if (!shader->init(glk::get_data_path() + "/shader/" + shader_name)) {
     shader.reset();


### PR DESCRIPTION
Continuing #55 

This PR:

* fixes `example/gl_test_field_example.cpp` segmentation vault by correctly (?) initializing the number of color buffers in `gl_canvas`. Please let me know if my thinking is correct here.
* Correctly loads bunny texture: The gui menu doesn't exactly match the main switch case in `Primitives::create_primitive`. Because case `COORDINATE_SYSTEM` falls through to `SOLID_COORDINATE_SYSTEM` increment bunny toggle from gui (in items) by one if primitive type is 6. To maintain a valid imGui combo, this has to be done in a separate variable

Note: I used your clang format file for formatting, which introduced some syntax changes