### PR TITLE
Add window flag setting to subviewer

### DIFF
--- a/include/guik/viewer/light_viewer_context.hpp
+++ b/include/guik/viewer/light_viewer_context.hpp
@@ -36,7 +36,7 @@ public:
 
   void set_size(const Eigen::Vector2i& size);
   void set_clear_color(const Eigen::Vector4f& color);
-  void set_pos(const Eigen::Vector2i& pos, ImGuiCond cond = ImGuiCond_FirstUseEver);
+  void set_pos(const Eigen::Vector2i& pos, ImGuiCond cond = ImGuiCond_FirstUseEver, ImGuiWindowFlags = 0);
 
   virtual void clear();
   virtual void clear_text();

--- a/src/guik/viewer/light_viewer_context.cpp
+++ b/src/guik/viewer/light_viewer_context.cpp
@@ -46,13 +46,13 @@ void LightViewerContext::set_clear_color(const Eigen::Vector4f& color) {
   canvas->set_clear_color(color);
 }
 
-void LightViewerContext::set_pos(const Eigen::Vector2i& pos, ImGuiCond cond) {
+void LightViewerContext::set_pos(const Eigen::Vector2i& pos, ImGuiCond cond, ImGuiWindowFlags flags) {
   int x = pos[0];
   int y = pos[1];
 
   guik::LightViewer::instance()->invoke([=] {
     ImGui::SetNextWindowPos(ImVec2(x, y), cond);
-    ImGui::Begin(context_name.c_str());
+    ImGui::Begin(context_name.c_str(), nullptr, flags);
     ImGui::End();
   });
 }

--- a/src/python/guik.cpp
+++ b/src/python/guik.cpp
@@ -166,7 +166,7 @@ void define_guik(py::module_& m) {
   py::class_<guik::LightViewerContext, std::shared_ptr<guik::LightViewerContext>>(guik_, "LightViewerContext")
     .def("set_size", &guik::LightViewerContext::set_size)
     .def("set_clear_color", &guik::LightViewerContext::set_clear_color)
-    .def("set_pos", &guik::LightViewerContext::set_pos, "", py::arg("pos"), py::arg("cond") = static_cast<int>(ImGuiCond_FirstUseEver))
+    .def("set_pos", &guik::LightViewerContext::set_pos, "", py::arg("pos"), py::arg("cond") = static_cast<int>(ImGuiCond_FirstUseEver), py::arg("flags") = 0)
     .def("clear", &guik::LightViewerContext::clear)
     .def("clear_text", &guik::LightViewerContext::clear_text)
     .def("append_text", &guik::LightViewerContext::append_text)


### PR DESCRIPTION
While the current implementation allows users to set the size, position, and background color of a subviewer, it doesn't allow users to adjust the window flags. This PR adds `ImGuiWindowFlags` as an additional argument to `LightViewerContext::set_pos`, so that users can freely set window flags for the subviewer. 

To be frank, I think modifying `set_pos` feels like a hack. The interface would be nicer if users could do something like `viewer->sub_viewer(name, size, flags)` or `viewer->sub_viewer(name, size, position, flags)`. However, this requires flags to be managed as a private variable of `LightViewerContext`, so that it can be used to create a new window [here](https://github.com/koide3/iridescence/blob/7e26b668aac73989eaa1761579d63570652b9686/src/guik/viewer/light_viewer_context.cpp#L92) and update window position [here](https://github.com/koide3/iridescence/blob/7e26b668aac73989eaa1761579d63570652b9686/src/guik/viewer/light_viewer_context.cpp#L55C40-L55C40). 

I'm not sure if this will be a desirable addition in the upstream, but I needed it in my use case, so I added it. Please feel free to close this PR if you deem it's not needed.

