### PR TITLE
async interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(gl_imgui SHARED
   thirdparty/ImGuizmo/ImGuizmo.cpp
   thirdparty/ImGuizmo/ImSequencer.cpp
   thirdparty/implot/implot.cpp
+  thirdparty/implot/implot_demo.cpp
   thirdparty/implot/implot_items.cpp
   thirdparty/imgui/backends/imgui_impl_glfw.cpp
   thirdparty/imgui/backends/imgui_impl_opengl3.cpp
@@ -127,6 +128,7 @@ add_library(iridescence SHARED
   src/guik/camera/static_camera_control.cpp
   src/guik/camera/projection_control.cpp
   src/guik/camera/basic_projection_control.cpp
+  src/guik/viewer/plot_data.cpp
   src/guik/viewer/light_viewer.cpp
   src/guik/viewer/light_viewer_context.cpp
   src/guik/viewer/light_viewer_context_util.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,8 @@ add_library(iridescence SHARED
   src/guik/viewer/light_viewer.cpp
   src/guik/viewer/light_viewer_context.cpp
   src/guik/viewer/light_viewer_context_util.cpp
+  src/guik/viewer/async_light_viewer.cpp
+  src/guik/viewer/async_light_viewer_context.cpp
   src/guik/viewer/viewer_ui.cpp
   src/guik/viewer/info_window.cpp
   src/guik/viewer/anonymous.cpp

--- a/docs/drawables.md
+++ b/docs/drawables.md
@@ -341,3 +341,31 @@ viewer->update_image("group1/image0", texture);
 ```
 
 ![Screenshot_20230101_011918](https://user-images.githubusercontent.com/31344317/210149509-c096fdcb-7337-44bf-833d-ce369378bbe1.png)
+
+
+## Plots (ImPlot)
+
+```cpp
+#include <implot.h>
+#include <guik/viewer/light_viewer.hpp>
+
+
+std::vector<double> xs = ...;
+std::vector<double> ys = ...;
+
+// Basic plotting
+viewer->setup_plot("curves_y", 1024, 256);
+viewer->update_plot_line("curves_y", "sin", ys_sin);  // When only Y values are given, X values become index IDs
+viewer->update_plot_stairs("curves_y", "sin_stairs", ys_sin);
+
+
+std::vector<double> xs_circle = ...;
+std::vector<double> ys_circle = ...;
+
+// If a plot name contains "/", the string before the slash is recognized as a group name.
+// Plots with the same group name are displayed in the same tab.
+viewer->setup_plot("group02/circle", 1024, 1024, ImPlotFlags_Equal);
+viewer->update_plot_line("group02/circle", "circle", xs_circle, ys_circle, ImPlotLineFlags_Loop);
+```
+
+![Screenshot_20231212_103830](https://github.com/koide3/iridescence/assets/31344317/0036c0ab-63bb-451f-8f0f-e8931c820f71)

--- a/docs/multithread.md
+++ b/docs/multithread.md
@@ -47,3 +47,37 @@ int main(int argc, char** argv) {
 viewer->append_text("test");
 viewer->clear_text();
 ```
+
+## AsyncViewer
+
+If you want to keep the viewer interactive while your program is doing some blocking operations, `guik::AsyncLightViewer` would be helpful. This class creates the viewer instance in a background thread and performs visualization tasks in a way thread safe. See `06_light_viewer_async.cpp`.
+
+```cpp
+#include <guik/viewer/async_light_viewer.hpp>
+
+int main(int argc, char** argv) {
+  // AsyncViewer creates and runs the viewer in a background thread.
+  auto async_viewer = guik::async_viewer();
+
+  // Use AsyncViewer interfaces for safe viewer data manipulation.
+  // AsyncViewer will be kept interactive even while the main thread is sleeping.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  async_viewer->update_wire_sphere("sphere1", guik::FlatRed().translate(0.0f, 0.0f, 0.0f));
+
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  async_viewer->update_wire_sphere("sphere2", guik::FlatGreen().translate(2.0f, 0.0f, 0.0f));
+
+  // Wait for the viewer to be closed.
+  guik::async_wait();
+}
+```
+
+!!! warning
+    Because AsyncViewer runs the viewer in another thread, calling the standard viewer functions in this main thread is unsafe.
+
+    ```cpp
+      auto async_viewer = guik::async_viewer();
+
+      // The below line may cause segfaults and program crashes.
+      // guik::viewer()->update_sphere("sphere0", guik::FlatBlue());
+    ```

--- a/include/guik/hovered_drawings.hpp
+++ b/include/guik/hovered_drawings.hpp
@@ -15,7 +15,7 @@ public:
 
 class HoveredDrawings {
 public:
-  HoveredDrawings(const std::shared_ptr<guik::LightViewerContext>& context = guik::LightViewer::instance());
+  HoveredDrawings(guik::LightViewerContext* context = guik::LightViewer::instance());
   ~HoveredDrawings();
 
   void add(const Eigen::Vector3f& pt, const std::shared_ptr<HoveredDrawing>& drawing);

--- a/include/guik/viewer/async_light_viewer.hpp
+++ b/include/guik/viewer/async_light_viewer.hpp
@@ -27,7 +27,22 @@ public:
   void invoke(const std::function<void()>& func);
   void invoke_after_rendering(const std::function<void()>& func);
 
-  // This method causes a synchronization with the visualization thread.
+  void clear_images();
+  void remove_image(const std::string& name);
+  void update_image(const std::string& name, int width, int height, const std::vector<unsigned  char>& rgba_bytes, double scale = -1.0, int order = -1);
+
+  void clear_plots();
+  void remove_plot(const std::string& plot_name, const std::string& label = "");
+  void setup_plot(const std::string& plot_name, int width, int height, int plot_flags = 0, int x_flags = 0, int y_flags = 0, int order = -1);
+  void update_plot(const std::string& plot_name, const std::string& label, const std::shared_ptr<const PlotData>& plot);
+  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, size_t max_num_data = 2048);
+  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, size_t max_num_data = 2048);
+  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& ys);
+  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys);
+  void update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& ys);
+  void update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys);
+
+  // This method causes synchronization with the visualization thread.
   // Do not call this frequently.
   AsyncLightViewerContext async_sub_viewer(const std::string& context_name, const Eigen::Vector2i& canvas_size = Eigen::Vector2i(-1, -1));
 

--- a/include/guik/viewer/async_light_viewer.hpp
+++ b/include/guik/viewer/async_light_viewer.hpp
@@ -38,8 +38,8 @@ private:
   std::thread thread;
 };
 
-inline AsyncLightViewer* async_viewer() {
-  return AsyncLightViewer::instance();
+inline AsyncLightViewer* async_viewer(const Eigen::Vector2i& size = Eigen::Vector2i(-1,  -1), bool background = false, const std::string& title = "screen") {
+  return AsyncLightViewer::instance(size, background, title);
 }
 
 inline void async_destroy() {

--- a/include/guik/viewer/async_light_viewer.hpp
+++ b/include/guik/viewer/async_light_viewer.hpp
@@ -15,8 +15,13 @@ private:
 public:
   virtual ~AsyncLightViewer();
 
+  /// @brief Create and run the viewer in a background thread
   static AsyncLightViewer* instance(const Eigen::Vector2i& size = Eigen::Vector2i(-1, -1), bool background = false, const std::string& title = "screen");
+
+  /// @brief Destroy the viewer in the background thread
   static void destroy();
+
+  /// @brief Wait for the viewer to be closed
   static void wait();
 
   void invoke(const std::function<void()>& func);

--- a/include/guik/viewer/async_light_viewer.hpp
+++ b/include/guik/viewer/async_light_viewer.hpp
@@ -29,18 +29,24 @@ public:
 
   void clear_images();
   void remove_image(const std::string& name);
-  void update_image(const std::string& name, int width, int height, const std::vector<unsigned  char>& rgba_bytes, double scale = -1.0, int order = -1);
+  void update_image(const std::string& name, int width, int height, const std::vector<unsigned char>& rgba_bytes, double scale = -1.0, int order = -1);
 
   void clear_plots();
   void remove_plot(const std::string& plot_name, const std::string& label = "");
   void setup_plot(const std::string& plot_name, int width, int height, int plot_flags = 0, int x_flags = 0, int y_flags = 0, int order = -1);
   void update_plot(const std::string& plot_name, const std::string& label, const std::shared_ptr<const PlotData>& plot);
-  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, size_t max_num_data = 2048);
-  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, size_t max_num_data = 2048);
-  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& ys);
-  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys);
-  void update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& ys);
-  void update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys);
+  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int line_flags = 0, size_t max_num_data = 2048);
+  void update_plot_line(
+    const std::string& plot_name,
+    const std::string& label,
+    const std::vector<double>& xs,
+    const std::vector<double>& ys,
+    int line_flags = 0,
+    size_t max_num_data = 2048);
+  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int scatter_flags = 0);
+  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, int scatter_flags = 0);
+  void update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int stairs_flags = 0);
+  void update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, int stairs_flags = 0);
 
   // This method causes synchronization with the visualization thread.
   // Do not call this frequently.
@@ -53,7 +59,7 @@ private:
   std::thread thread;
 };
 
-inline AsyncLightViewer* async_viewer(const Eigen::Vector2i& size = Eigen::Vector2i(-1,  -1), bool background = false, const std::string& title = "screen") {
+inline AsyncLightViewer* async_viewer(const Eigen::Vector2i& size = Eigen::Vector2i(-1, -1), bool background = false, const std::string& title = "screen") {
   return AsyncLightViewer::instance(size, background, title);
 }
 

--- a/include/guik/viewer/async_light_viewer.hpp
+++ b/include/guik/viewer/async_light_viewer.hpp
@@ -1,0 +1,50 @@
+#ifndef GUIK_ASYNC_LIGHT_VIEWER_HPP
+#define GUIK_ASYNC_LIGHT_VIEWER_HPP
+
+#include <atomic>
+#include <thread>
+#include <guik/viewer/light_viewer.hpp>
+#include <guik/viewer/async_light_viewer_context.hpp>
+
+namespace guik {
+
+class AsyncLightViewer : public AsyncLightViewerContext {
+private:
+  AsyncLightViewer(const Eigen::Vector2i& size, bool background, const std::string& title);
+
+public:
+  virtual ~AsyncLightViewer();
+
+  static AsyncLightViewer* instance(const Eigen::Vector2i& size = Eigen::Vector2i(-1, -1), bool background = false, const std::string& title = "screen");
+  static void destroy();
+  static void wait();
+
+  void invoke(const std::function<void()>& func);
+  void invoke_after_rendering(const std::function<void()>& func);
+
+  // This method causes a synchronization with the visualization thread.
+  // Do not call this frequently.
+  AsyncLightViewerContext async_sub_viewer(const std::string& context_name, const Eigen::Vector2i& canvas_size = Eigen::Vector2i(-1, -1));
+
+private:
+  static std::unique_ptr<AsyncLightViewer> inst;
+
+  std::atomic_bool kill_switch;
+  std::thread thread;
+};
+
+inline AsyncLightViewer* async_viewer() {
+  return AsyncLightViewer::instance();
+}
+
+inline void async_destroy() {
+  AsyncLightViewer::destroy();
+}
+
+inline void async_wait() {
+  AsyncLightViewer::wait();
+}
+
+}  // namespace guik
+
+#endif

--- a/include/guik/viewer/async_light_viewer_context.hpp
+++ b/include/guik/viewer/async_light_viewer_context.hpp
@@ -1,95 +1,34 @@
-#ifndef GUIK_LIGHT_VIEWER_CONTEXT_HPP
-#define GUIK_LIGHT_VIEWER_CONTEXT_HPP
+#ifndef GUIK_ASYNC_LIGHT_VIEWER_CONTEXT_HPP
+#define GUIK_ASYNC_LIGHT_VIEWER_CONTEXT_HPP
 
-#include <mutex>
-#include <deque>
-#include <regex>
-#include <memory>
-#include <optional>
-#include <unordered_map>
-
-#include <glk/drawable.hpp>
-#include <glk/colormap.hpp>
-#include <glk/type_conversion.hpp>
-#include <guik/gl_canvas.hpp>
-#include <guik/camera/camera_control.hpp>
-#include <guik/camera/projection_control.hpp>
-#include <guik/viewer/shader_setting.hpp>
-#include <guik/viewer/anonymous.hpp>
-
-namespace glk {
-class ThinLines;
-class PointCloudBuffer;
-}  // namespace glk
+#include <guik/viewer/light_viewer_context.hpp>
 
 namespace guik {
 
-class AsyncLightViewerContext;
-
-class LightViewerContext {
+/**
+ * @brief Async interface to manipulate LightViewerContext.
+ *        All OpenGL operations will be done in the viewer thread through `invoke` method.
+ *        Note that async operations come at a cost of data copy.
+ */
+class AsyncLightViewerContext {
 public:
-  LightViewerContext(const std::string& context_name);
-  virtual ~LightViewerContext();
+  AsyncLightViewerContext();  // context must be set manually
+  AsyncLightViewerContext(LightViewerContext* context);
+  ~AsyncLightViewerContext();
 
-  void draw_ui();
-  void draw_gl();
-
-  bool init_canvas(const Eigen::Vector2i& size);
-
-  void set_size(const Eigen::Vector2i& size);
-  void set_clear_color(const Eigen::Vector4f& color);
-  void set_pos(const Eigen::Vector2i& pos, ImGuiCond cond = ImGuiCond_FirstUseEver, ImGuiWindowFlags = 0);
-
-  virtual void clear();
-  virtual void clear_text();
-  virtual void append_text(const std::string& text);
-  virtual void register_ui_callback(const std::string& name, const std::function<void()>& callback = 0);
-
-  guik::ShaderSetting& shader_setting() { return global_shader_setting; }
-  const guik::ShaderSetting& shader_setting() const { return global_shader_setting; }
+  void clear();
+  void clear_text();
+  void append_text(const std::string& text);
 
   void disable_xy_grid() { set_draw_xy_grid(false); }
   void enable_xy_grid() { set_draw_xy_grid(true); }
   void set_draw_xy_grid(bool draw_xy_grid);
   void set_colormap(glk::COLORMAP colormap);
-  void set_screen_effect(const std::shared_ptr<glk::ScreenEffect>& effect);
-  const std::shared_ptr<glk::ScreenEffect>& get_screen_effect() const;
-  void set_bg_texture(const std::shared_ptr<glk::Texture>& bg_texture);
-
-  void enable_decimal_rendering();
-  void enable_normal_buffer();
-  void enable_info_buffer();
-  void enable_partial_rendering(double clear_thresh = 1e-6);
-
-  bool normal_buffer_enabled() const;
-  bool info_buffer_enabled() const;
-  bool partial_rendering_enabled() const;
-
-  const glk::Texture& color_buffer() const;
-  const glk::Texture& depth_buffer() const;
-  const glk::Texture& normal_buffer() const;
-  const glk::Texture& info_buffer() const;
-  const glk::Texture& dynamic_flag_buffer() const;
 
   void clear_drawables();
   void clear_drawables(const std::function<bool(const std::string&)>& fn);
-
-  std::unordered_map<std::string, std::pair<ShaderSetting::Ptr, glk::Drawable::ConstPtr>>& get_drawables();
-
-  std::pair<ShaderSetting::Ptr, glk::Drawable::ConstPtr> find_drawable(const std::string& name);
   void remove_drawable(const std::string& name);
   void remove_drawable(const std::regex& regex);
-  void update_drawable(const std::string& name, const glk::Drawable::ConstPtr& drawable, const ShaderSetting& shader_setting = ShaderSetting());
-
-  void clear_drawable_filters();
-  void register_drawable_filter(const std::string& filter_name, const std::function<bool(const std::string&)>& filter = 0);
-
-  void clear_partial_rendering();
-
-  const std::shared_ptr<CameraControl>& get_camera_control() const;
-  const std::shared_ptr<ProjectionControl>& get_projection_control() const;
-  void set_camera_control(const std::shared_ptr<CameraControl>& camera_control);
-  void set_projection_control(const std::shared_ptr<ProjectionControl>& projection_control);
 
   void reset_center();
   void lookat(const Eigen::Vector3f& pt);
@@ -98,30 +37,14 @@ public:
   void use_topdown_camera_control(double distance = 80.0, double theta = 0.0);
   void use_arcball_camera_control(double distance = 80.0, double theta = 0.0, double phi = -60.0f * M_PI / 180.0f);
 
-  guik::GLCanvas& get_canvas();
-  Eigen::Vector2i canvas_tl() const { return canvas_rect_min; }
-  Eigen::Vector2i canvas_br() const { return canvas_rect_max; }
-  Eigen::Vector2i canvas_size() const { return canvas->size; }
-  Eigen::Matrix4f view_matrix() const { return canvas->camera_control->view_matrix(); }
-  Eigen::Matrix4f projection_matrix() const { return canvas->projection_control->projection_matrix(); }
-
-  Eigen::Vector4i pick_info(const Eigen::Vector2i& p, int window = 2) const;
-  float pick_depth(const Eigen::Vector2i& p, int window = 2) const;
-  Eigen::Vector3f unproject(const Eigen::Vector2i& p, float depth) const;
-  std::optional<Eigen::Vector3f> pick_point(int button = 0, int window = 2, Eigen::Vector4i* info = nullptr) const;
-
-  // Async
-  AsyncLightViewerContext async();
-
   // utility methods to directly create and update drawables
   // PointCloudBuffer
-  std::shared_ptr<glk::PointCloudBuffer> update_points(const std::string& name, const float* data, int stride, int num_points, const ShaderSetting& shader_setting);
+  void update_points(const std::string& name, const float* data, int stride, int num_points, const ShaderSetting& shader_setting);
   template <typename Scalar, int Dim>
-  std::shared_ptr<glk::PointCloudBuffer> update_points(const std::string& name, const Eigen::Matrix<Scalar, Dim, 1>* points, int num_points, const ShaderSetting& shader_setting);
+  void update_points(const std::string& name, const Eigen::Matrix<Scalar, Dim, 1>* points, int num_points, const ShaderSetting& shader_setting);
 
   template <typename Scalar, int Dim, typename Allocator>
-  std::shared_ptr<glk::PointCloudBuffer>
-  update_points(const std::string& name, const std::vector<Eigen::Matrix<Scalar, Dim, 1>, Allocator>& points, const ShaderSetting& shader_setting);
+  void update_points(const std::string& name, const std::vector<Eigen::Matrix<Scalar, Dim, 1>, Allocator>& points, const ShaderSetting& shader_setting);
 
   // NormalDistributions
   template <typename Scalar, int Dim>
@@ -142,7 +65,7 @@ public:
     const ShaderSetting& shader_setting);
 
   // ThinLines
-  std::shared_ptr<glk::ThinLines> update_thin_lines(
+  void update_thin_lines(
     const std::string& name,
     const float* vertices,
     const float* colors,
@@ -153,11 +76,10 @@ public:
     const ShaderSetting& shader_setting);
 
   template <typename Scalar, int Dim>
-  std::shared_ptr<glk::ThinLines>
-  update_thin_lines(const std::string& name, const Eigen::Matrix<Scalar, Dim, 1>* points, int num_points, bool line_strip, const ShaderSetting& shader_setting);
+  void update_thin_lines(const std::string& name, const Eigen::Matrix<Scalar, Dim, 1>* points, int num_points, bool line_strip, const ShaderSetting& shader_setting);
 
   template <typename ScalarV, int DimV, typename ScalarC, int DimC>
-  std::shared_ptr<glk::ThinLines> update_thin_lines(
+  void update_thin_lines(
     const std::string& name,
     const Eigen::Matrix<ScalarV, DimV, 1>* points,
     const Eigen::Matrix<ScalarC, DimC, 1>* colors,
@@ -166,7 +88,7 @@ public:
     const ShaderSetting& shader_setting);
 
   template <typename ScalarV, int DimV, typename ScalarC, int DimC>
-  std::shared_ptr<glk::ThinLines> update_thin_lines(
+  void update_thin_lines(
     const std::string& name,
     const Eigen::Matrix<ScalarV, DimV, 1>* points,
     const Eigen::Matrix<ScalarC, DimC, 1>* colors,
@@ -177,10 +99,10 @@ public:
     const ShaderSetting& shader_setting);
 
   template <typename Point, typename Alloc>
-  std::shared_ptr<glk::ThinLines> update_thin_lines(const std::string& name, const std::vector<Point, Alloc>& points, bool line_strip, const ShaderSetting& shader_setting);
+  void update_thin_lines(const std::string& name, const std::vector<Point, Alloc>& points, bool line_strip, const ShaderSetting& shader_setting);
 
   template <typename Point, typename Alloc>
-  std::shared_ptr<glk::ThinLines> update_thin_lines(
+  void update_thin_lines(
     const std::string& name,
     const std::vector<Point, Alloc>& points,
     const std::vector<unsigned int>& indices,
@@ -188,7 +110,7 @@ public:
     const ShaderSetting& shader_setting);
 
   template <typename Point, typename AllocP, typename Color, typename AllocC>
-  std::shared_ptr<glk::ThinLines> update_thin_lines(
+  void update_thin_lines(
     const std::string& name,
     const std::vector<Point, AllocP>& points,
     const std::vector<Color, AllocC>& colors,
@@ -196,7 +118,7 @@ public:
     const ShaderSetting& shader_setting);
 
   template <typename Point, typename AllocP, typename Color, typename AllocC>
-  std::shared_ptr<glk::ThinLines> update_thin_lines(
+  void update_thin_lines(
     const std::string& name,
     const std::vector<Point, AllocP>& points,
     const std::vector<Color, AllocC>& colors,
@@ -218,30 +140,13 @@ public:
   void update_wire_frustum(const std::string& name, const ShaderSetting& shader_setting);
 
 protected:
-  std::string context_name;
-  Eigen::Vector2i canvas_rect_min;
-  Eigen::Vector2i canvas_rect_max;
-  std::unique_ptr<guik::GLCanvas> canvas;
-  guik::ShaderSetting global_shader_setting;
-
-  bool draw_xy_grid;
-  bool decimal_rendering;
-
-  Eigen::Matrix4f last_projection_view_matrix;
-
-  std::unordered_map<std::string, std::function<bool(const std::string&)>> drawable_filters;
-  std::unordered_map<std::string, std::pair<ShaderSetting::Ptr, glk::Drawable::ConstPtr>> drawables;
-
-  std::mutex sub_texts_mutex;
-  std::deque<std::string> sub_texts;
-  std::unordered_map<std::string, std::function<void()>> sub_ui_callbacks;
+  LightViewerContext* context;
 };
 
 // template methods
 // PointCloud
 template <typename Scalar, int Dim>
-std::shared_ptr<glk::PointCloudBuffer>
-LightViewerContext::update_points(const std::string& name, const Eigen::Matrix<Scalar, Dim, 1>* points, int num_points, const ShaderSetting& shader_setting) {
+void AsyncLightViewerContext::update_points(const std::string& name, const Eigen::Matrix<Scalar, Dim, 1>* points, int num_points, const ShaderSetting& shader_setting) {
   if constexpr (std::is_same<Scalar, float>::value) {
     return update_points(name, reinterpret_cast<const float*>(points), sizeof(float) * Dim, num_points, shader_setting);
   } else {
@@ -251,14 +156,13 @@ LightViewerContext::update_points(const std::string& name, const Eigen::Matrix<S
 }
 
 template <typename Scalar, int Dim, typename Allocator>
-std::shared_ptr<glk::PointCloudBuffer>
-LightViewerContext::update_points(const std::string& name, const std::vector<Eigen::Matrix<Scalar, Dim, 1>, Allocator>& points, const ShaderSetting& shader_setting) {
+void AsyncLightViewerContext::update_points(const std::string& name, const std::vector<Eigen::Matrix<Scalar, Dim, 1>, Allocator>& points, const ShaderSetting& shader_setting) {
   return update_points(name, points.data(), points.size(), shader_setting);
 }
 
 // NormalDistributions
 template <typename Scalar, int Dim, typename Alloc1, typename Alloc2>
-void LightViewerContext::update_normal_dists(
+void AsyncLightViewerContext::update_normal_dists(
   const std::string& name,
   const std::vector<Eigen::Matrix<Scalar, Dim, 1>, Alloc1> points,
   const std::vector<Eigen::Matrix<Scalar, Dim, Dim>, Alloc2> covs,
@@ -269,8 +173,12 @@ void LightViewerContext::update_normal_dists(
 
 // ThinLines
 template <typename Scalar, int Dim>
-std::shared_ptr<glk::ThinLines>
-LightViewerContext::update_thin_lines(const std::string& name, const Eigen::Matrix<Scalar, Dim, 1>* points, int num_points, bool line_strip, const ShaderSetting& shader_setting) {
+void AsyncLightViewerContext::update_thin_lines(
+  const std::string& name,
+  const Eigen::Matrix<Scalar, Dim, 1>* points,
+  int num_points,
+  bool line_strip,
+  const ShaderSetting& shader_setting) {
   if constexpr (std::is_same<Scalar, float>::value && Dim == 3) {
     return update_thin_lines(name, reinterpret_cast<const float*>(points), nullptr, num_points, nullptr, 0, line_strip, shader_setting);
   } else {
@@ -280,7 +188,7 @@ LightViewerContext::update_thin_lines(const std::string& name, const Eigen::Matr
 }
 
 template <typename ScalarV, int DimV, typename ScalarC, int DimC>
-std::shared_ptr<glk::ThinLines> LightViewerContext::update_thin_lines(
+void AsyncLightViewerContext::update_thin_lines(
   const std::string& name,
   const Eigen::Matrix<ScalarV, DimV, 1>* points,
   const Eigen::Matrix<ScalarC, DimC, 1>* colors,
@@ -297,7 +205,7 @@ std::shared_ptr<glk::ThinLines> LightViewerContext::update_thin_lines(
 }
 
 template <typename ScalarV, int DimV, typename ScalarC, int DimC>
-std::shared_ptr<glk::ThinLines> LightViewerContext::update_thin_lines(
+void AsyncLightViewerContext::update_thin_lines(
   const std::string& name,
   const Eigen::Matrix<ScalarV, DimV, 1>* points,
   const Eigen::Matrix<ScalarC, DimC, 1>* colors,
@@ -316,13 +224,12 @@ std::shared_ptr<glk::ThinLines> LightViewerContext::update_thin_lines(
 }
 
 template <typename Point, typename Alloc>
-std::shared_ptr<glk::ThinLines>
-LightViewerContext::update_thin_lines(const std::string& name, const std::vector<Point, Alloc>& points, bool line_strip, const ShaderSetting& shader_setting) {
+void AsyncLightViewerContext::update_thin_lines(const std::string& name, const std::vector<Point, Alloc>& points, bool line_strip, const ShaderSetting& shader_setting) {
   return update_thin_lines(name, points.data(), points.size(), line_strip, shader_setting);
 }
 
 template <typename Point, typename Alloc>
-std::shared_ptr<glk::ThinLines> LightViewerContext::update_thin_lines(
+void AsyncLightViewerContext::update_thin_lines(
   const std::string& name,
   const std::vector<Point, Alloc>& points,
   const std::vector<unsigned int>& indices,
@@ -332,7 +239,7 @@ std::shared_ptr<glk::ThinLines> LightViewerContext::update_thin_lines(
 }
 
 template <typename Point, typename AllocP, typename Color, typename AllocC>
-std::shared_ptr<glk::ThinLines> LightViewerContext::update_thin_lines(
+void AsyncLightViewerContext::update_thin_lines(
   const std::string& name,
   const std::vector<Point, AllocP>& points,
   const std::vector<Color, AllocC>& colors,
@@ -342,7 +249,7 @@ std::shared_ptr<glk::ThinLines> LightViewerContext::update_thin_lines(
 }
 
 template <typename Point, typename AllocP, typename Color, typename AllocC>
-std::shared_ptr<glk::ThinLines> LightViewerContext::update_thin_lines(
+void AsyncLightViewerContext::update_thin_lines(
   const std::string& name,
   const std::vector<Point, AllocP>& points,
   const std::vector<Color, AllocC>& colors,

--- a/include/guik/viewer/async_light_viewer_context.hpp
+++ b/include/guik/viewer/async_light_viewer_context.hpp
@@ -19,6 +19,7 @@ public:
   void clear();
   void clear_text();
   void append_text(const std::string& text);
+  void register_ui_callback(const std::string& name, const std::function<void()>& callback = 0);
 
   void disable_xy_grid() { set_draw_xy_grid(false); }
   void enable_xy_grid() { set_draw_xy_grid(true); }

--- a/include/guik/viewer/light_viewer.hpp
+++ b/include/guik/viewer/light_viewer.hpp
@@ -39,7 +39,7 @@ public:
 
   void clear_images();
   void remove_image(const std::string& name);
-  void update_image(const std::string& name, const std::shared_ptr<glk::Texture>& image, double scale = -1.0);
+  void update_image(const std::string& name, const std::shared_ptr<glk::Texture>& image, double scale = -1.0, int order = -1);
 
   void clear_plots();
   void remove_plot(const std::string& plot_name, const std::string& label = "");
@@ -81,7 +81,7 @@ private:
   std::deque<std::string> texts;
   std::unordered_map<std::string, std::function<void()>> ui_callbacks;
 
-  std::unordered_map<std::string, std::pair<double, std::shared_ptr<glk::Texture>>> images;
+  std::unordered_map<std::string, std::tuple<double, std::shared_ptr<glk::Texture>, int>> images;
   std::vector<std::shared_ptr<glk::Texture>> images_in_rendering;
 
   std::unordered_map<std::string, PlotSetting> plot_settings;

--- a/include/guik/viewer/light_viewer.hpp
+++ b/include/guik/viewer/light_viewer.hpp
@@ -9,6 +9,7 @@
 #include <glk/drawable.hpp>
 #include <guik/gl_canvas.hpp>
 #include <guik/imgui_application.hpp>
+#include <guik/viewer/plot_data.hpp>
 #include <guik/viewer/shader_setting.hpp>
 #include <guik/viewer/light_viewer_context.hpp>
 
@@ -37,6 +38,14 @@ public:
   void clear_images();
   void remove_image(const std::string& name);
   void update_image(const std::string& name, const std::shared_ptr<glk::Texture>& image, double scale = -1.0);
+
+  void clear_plots();
+  void remove_plot(const std::string& plot_name, const std::string& label = "");
+  void setup_plot(const std::string& plot_name, int width, int height, int flags = 0);
+  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int x_flags = 0, int y_flags = 0);
+  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, int x_flags = 0, int y_flags = 0);
+  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, int x_flags = 0, int y_flags = 0);
+  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, int x_flags = 0, int y_flags = 0);
 
   std::shared_ptr<LightViewerContext> sub_viewer(const std::string& context_name, const Eigen::Vector2i& canvas_size = Eigen::Vector2i(-1, -1));
 
@@ -69,6 +78,9 @@ private:
 
   std::unordered_map<std::string, std::pair<double, std::shared_ptr<glk::Texture>>> images;
   std::vector<std::shared_ptr<glk::Texture>> images_in_rendering;
+
+  std::unordered_map<std::string, std::tuple<int, int, int>> plot_settings;
+  std::unordered_map<std::string, std::vector<PlotData::ConstPtr>> plot_data;
 
   std::unordered_map<std::string, std::shared_ptr<LightViewerContext>> sub_contexts;
 

--- a/include/guik/viewer/light_viewer.hpp
+++ b/include/guik/viewer/light_viewer.hpp
@@ -45,12 +45,18 @@ public:
   void remove_plot(const std::string& plot_name, const std::string& label = "");
   void setup_plot(const std::string& plot_name, int width, int height, int plot_flags = 0, int x_flags = 0, int y_flags = 0, int order = -1);
   void update_plot(const std::string& plot_name, const std::string& label, const std::shared_ptr<const PlotData>& plot);
-  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, size_t max_num_data = 2048);
-  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, size_t max_num_data = 2048);
-  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& ys);
-  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys);
-  void update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& ys);
-  void update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys);
+  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int line_flags = 0, size_t max_num_data = 2048);
+  void update_plot_line(
+    const std::string& plot_name,
+    const std::string& label,
+    const std::vector<double>& xs,
+    const std::vector<double>& ys,
+    int line_flags = 0,
+    size_t max_num_data = 2048);
+  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int scatter_flags = 0);
+  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, int scatter_flags = 0);
+  void update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int stairs_flags = 0);
+  void update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, int stairs_flags = 0);
 
   std::shared_ptr<LightViewerContext> sub_viewer(const std::string& context_name, const Eigen::Vector2i& canvas_size = Eigen::Vector2i(-1, -1));
 

--- a/include/guik/viewer/light_viewer.hpp
+++ b/include/guik/viewer/light_viewer.hpp
@@ -19,26 +19,8 @@ public:
   LightViewer();
   virtual ~LightViewer();
 
-  static std::shared_ptr<LightViewer> instance(const Eigen::Vector2i& size = Eigen::Vector2i(-1, -1), bool background = false, const std::string& title = "screen") {
-    if (!inst) {
-      Eigen::Vector2i init_size = (size.array() > 0).all() ? size : Eigen::Vector2i(1920, 1080);
-      inst.reset(new LightViewer());
-      inst->init(init_size, "#version 330", background, title);
-    } else {
-      if ((size.array() > 0).all() && inst->window_size() != size) {
-        inst->resize(size);
-      }
-    }
-
-    return inst;
-  }
-
-  static void destroy() {
-    if (inst) {
-      inst->clear();
-      inst.reset();
-    }
-  }
+  static LightViewer* instance(const Eigen::Vector2i& size = Eigen::Vector2i(-1, -1), bool background = false, const std::string& title = "screen");
+  static void destroy();
 
   bool spin_until_click();
   bool toggle_spin_once();
@@ -75,7 +57,7 @@ private:
   virtual void draw_gl() override;
 
 private:
-  static std::shared_ptr<LightViewer> inst;
+  static std::unique_ptr<LightViewer> inst;
 
   std::unique_ptr<ViewerUI> viewer_ui;
   std::unique_ptr<InfoWindow> info_window;
@@ -97,11 +79,11 @@ private:
   std::deque<std::function<void()>> post_render_invoke_requests;
 };
 
-inline std::shared_ptr<LightViewer> viewer(const Eigen::Vector2i& size = Eigen::Vector2i(-1, -1), bool background = false, const std::string& title = "screen") {
+inline LightViewer* viewer(const Eigen::Vector2i& size = Eigen::Vector2i(-1, -1), bool background = false, const std::string& title = "screen") {
   return LightViewer::instance(size, background, title);
 }
 
-inline std::shared_ptr<LightViewer> viewer(const std::string& title, const Eigen::Vector2i& size = Eigen::Vector2i(-1, -1), bool background = false) {
+inline LightViewer* viewer(const std::string& title, const Eigen::Vector2i& size = Eigen::Vector2i(-1, -1), bool background = false) {
   return LightViewer::instance(size, background, title);
 }
 

--- a/include/guik/viewer/light_viewer.hpp
+++ b/include/guik/viewer/light_viewer.hpp
@@ -9,11 +9,13 @@
 #include <glk/drawable.hpp>
 #include <guik/gl_canvas.hpp>
 #include <guik/imgui_application.hpp>
-#include <guik/viewer/plot_data.hpp>
+#include <guik/viewer/plot_setting.hpp>
 #include <guik/viewer/shader_setting.hpp>
 #include <guik/viewer/light_viewer_context.hpp>
 
 namespace guik {
+
+struct PlotData;
 
 class LightViewer : public guik::Application, public guik::LightViewerContext {
 public:
@@ -41,11 +43,14 @@ public:
 
   void clear_plots();
   void remove_plot(const std::string& plot_name, const std::string& label = "");
-  void setup_plot(const std::string& plot_name, int width, int height, int flags = 0);
-  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int x_flags = 0, int y_flags = 0);
-  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, int x_flags = 0, int y_flags = 0);
-  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, int x_flags = 0, int y_flags = 0);
-  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, int x_flags = 0, int y_flags = 0);
+  void setup_plot(const std::string& plot_name, int width, int height, int plot_flags = 0, int x_flags = 0, int y_flags = 0, int order = -1);
+  void update_plot(const std::string& plot_name, const std::string& label, const std::shared_ptr<const PlotData>& plot);
+  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, size_t max_num_data = 2048);
+  void update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, size_t max_num_data = 2048);
+  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& ys);
+  void update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys);
+  void update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& ys);
+  void update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys);
 
   std::shared_ptr<LightViewerContext> sub_viewer(const std::string& context_name, const Eigen::Vector2i& canvas_size = Eigen::Vector2i(-1, -1));
 
@@ -79,8 +84,8 @@ private:
   std::unordered_map<std::string, std::pair<double, std::shared_ptr<glk::Texture>>> images;
   std::vector<std::shared_ptr<glk::Texture>> images_in_rendering;
 
-  std::unordered_map<std::string, std::tuple<int, int, int>> plot_settings;
-  std::unordered_map<std::string, std::vector<PlotData::ConstPtr>> plot_data;
+  std::unordered_map<std::string, PlotSetting> plot_settings;
+  std::unordered_map<std::string, std::vector<std::shared_ptr<const PlotData>>> plot_data;
 
   std::unordered_map<std::string, std::shared_ptr<LightViewerContext>> sub_contexts;
 

--- a/include/guik/viewer/plot_data.hpp
+++ b/include/guik/viewer/plot_data.hpp
@@ -1,0 +1,31 @@
+#ifndef GUIK_PLOT_DATA_HPP
+#define GUIK_PLOT_DATA_HPP
+
+#include <memory>
+#include <vector>
+#include <string>
+
+namespace guik  {
+
+struct PlotData {
+public:
+  using Ptr = std::shared_ptr<PlotData>;
+  using ConstPtr = std::shared_ptr<const PlotData>;
+
+  PlotData() : x_flags(0), y_flags(0) {}
+  ~PlotData() {}
+
+public:
+  std::vector<double> xs;
+  std::vector<double> ys;
+
+  std::string label;
+  std::string x_label;
+  std::string y_label;
+
+  int x_flags;
+  int y_flags;
+};
+}
+
+#endif

--- a/include/guik/viewer/plot_data.hpp
+++ b/include/guik/viewer/plot_data.hpp
@@ -5,27 +5,61 @@
 #include <vector>
 #include <string>
 
-namespace guik  {
+namespace guik {
 
 struct PlotData {
 public:
   using Ptr = std::shared_ptr<PlotData>;
   using ConstPtr = std::shared_ptr<const PlotData>;
 
-  PlotData() : x_flags(0), y_flags(0) {}
-  ~PlotData() {}
+  PlotData(const std::string& label) : label(label) {}
+  virtual ~PlotData() {}
+
+  virtual void plot() const = 0;
 
 public:
+  std::string label;
+};
+
+struct LinePlotData : public PlotData {
+public:
+  LinePlotData(const std::string& label) : PlotData(label), line_flags(0) {}
+  ~LinePlotData() {}
+
+  virtual void plot() const override;
+
+public:
+  int line_flags;
   std::vector<double> xs;
   std::vector<double> ys;
-
-  std::string label;
-  std::string x_label;
-  std::string y_label;
-
-  int x_flags;
-  int y_flags;
 };
-}
+
+struct ScatterPlotData : public PlotData {
+public:
+  ScatterPlotData(const std::string& label) : PlotData(label), scatter_flags(0) {}
+  ~ScatterPlotData() {}
+
+  virtual void plot() const override;
+
+public:
+  int scatter_flags;
+  std::vector<double> xs;
+  std::vector<double> ys;
+};
+
+struct StairsPlotData : public PlotData {
+public:
+  StairsPlotData(const std::string& label) : PlotData(label), stairs_flags(0) {}
+  ~StairsPlotData() {}
+
+  virtual void plot() const override;
+
+public:
+  int stairs_flags;
+  std::vector<double> xs;
+  std::vector<double> ys;
+};
+
+}  // namespace guik
 
 #endif

--- a/include/guik/viewer/plot_setting.hpp
+++ b/include/guik/viewer/plot_setting.hpp
@@ -1,0 +1,30 @@
+#ifndef GUIK_PLOT_SETTING_HPP
+#define GUIK_PLOT_SETTING_HPP
+
+#include <memory>
+#include <vector>
+#include <string>
+
+namespace guik {
+
+struct PlotSetting {
+public:
+  PlotSetting() : width(512), height(256), plot_flags(0), x_flags(0), y_flags(0), order(0) {}
+  ~PlotSetting() {}
+
+public:
+  int width;
+  int height;
+
+  std::string x_label;
+  std::string y_label;
+
+  int plot_flags;
+  int x_flags;
+  int y_flags;
+
+  int order;
+};
+}  // namespace guik
+
+#endif

--- a/src/example/05_light_viewer_multi_thread.cpp
+++ b/src/example/05_light_viewer_multi_thread.cpp
@@ -3,6 +3,7 @@
 #include <thread>
 #include <glk/pointcloud_buffer.hpp>
 #include <guik/viewer/light_viewer.hpp>
+#include <guik/viewer/async_light_viewer_context.hpp>
 
 // This function will run on a background thread
 void run() {
@@ -17,24 +18,30 @@ void run() {
     // The following code doesn't work here because GL objects must be created in the GUI thread
     // auto cloud_buffer = std::make_shared<glk::PointCloudBuffer>(points.data(), sizeof(float) * 3, points.size() / 3);
 
-    // Request to invoke a function in the GUI thread
-    guik::LightViewer::instance()->invoke([=] {
-      // This function will be called just before rendering in the GUI thread
+    auto viewer = guik::LightViewer::instance();
+
+    // Request to invoke a function in the GUI thread.
+    viewer->invoke([=] {
+      // This function will be called just before rendering in the GUI thread.
       auto cloud_buffer = std::make_shared<glk::PointCloudBuffer>(points.data(), sizeof(float) * 3, points.size() / 3);
-      guik::LightViewer::instance()->update_drawable("cloud_" + std::to_string(i), cloud_buffer, guik::FlatColor(Eigen::Vector4f::Random() * 2.0f).add("point_scale", 3.0f));
+      viewer->update_drawable("cloud_" + std::to_string(i), cloud_buffer, guik::FlatColor(Eigen::Vector4f::Random() * 2.0f).add("point_scale", 3.0f));
     });
 
-    // ```append_text``` and ```clear_texts``` are thread-safe
-    guik::LightViewer::instance()->append_text(std::to_string(i) + " : add points");
+    // Alternatively, async interfaces, which perform more or less the same operation as the above example, can be used.
+    viewer->async()
+      .update_points("cloud_" + std::to_string(i), points.data(), sizeof(float) * 3, points.size() / 3, guik::FlatColor(Eigen::Vector4f::Random() * 2.0f).add("point_scale", 3.0f));
+
+    // ```append_text``` and ```clear_texts``` are thread-safe.
+    viewer->append_text(std::to_string(i) + " : add points");
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 }
 
 int main(int argc, char** argv) {
-  // Usually, ```guik::LightViewer::instance()``` should be first called on the main thread,
+  // Usually, ```guik::LightViewer::instance()``` (or equivalent ```guik::viewer()```) should be first called on the main thread,
   // because once you create a viewer instance on a thread,
-  // you must do all GL operations and destory that instance on that thread
+  // you must do all GL operations and destory that instance on that thread.
   auto viewer = guik::LightViewer::instance();
 
   std::thread thread(run);

--- a/src/example/06_light_viewer_async.cpp
+++ b/src/example/06_light_viewer_async.cpp
@@ -1,0 +1,29 @@
+#include <thread>
+#include <guik/viewer/async_light_viewer.hpp>
+
+int main(int argc, char** argv) {
+  // AsyncViewer creates and runs the viewer in a background thread.
+  // This is helpful in situations you want to keep the viewer interactive while the main thread is doing some blocking operations.
+  // Note that this "fire-and-forget" style usage brings some limitations of possible operations and data copy overhead.
+  auto async_viewer = guik::async_viewer();
+
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  async_viewer->update_wire_sphere("sphere1", guik::FlatRed().translate(0.0f, 0.0f, 0.0f));
+
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  async_viewer->update_wire_sphere("sphere2", guik::FlatGreen().translate(2.0f, 0.0f, 0.0f));
+
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  async_viewer->update_wire_sphere("sphere3", guik::FlatBlue().translate(4.0f, 0.0f, 0.0f));
+
+  // ```async_sub_viewer``` causes a syncronization with the visualization thread.
+  // Do not call it frequently.
+  auto async_sub_viewer = async_viewer->async_sub_viewer("sub_viewer");
+  async_sub_viewer.update_wire_icosahedron("icosahedron", guik::FlatRed());
+
+  // Wait for the viewer to be closed.
+  // To terminate the async viewer immediately, call ```async_destroy``` instead.
+  guik::async_wait();
+
+  return 0;
+}

--- a/src/example/06_light_viewer_async.cpp
+++ b/src/example/06_light_viewer_async.cpp
@@ -7,6 +7,11 @@ int main(int argc, char** argv) {
   // Note that this "fire-and-forget" style usage brings some limitations of possible operations and data copy overhead.
   auto async_viewer = guik::async_viewer();
 
+  // Because the viewer is running in another thread, calling the standard viewer functions in this main thread is unsafe.
+  // Thus, the below line may cause segfaults and program crashes.
+  // guik::viewer()->update_sphere("sphere0", guik::FlatBlue());
+
+  // Use AsyncViewer interfaces for safe viewer data manipulation.
   std::this_thread::sleep_for(std::chrono::seconds(1));
   async_viewer->update_wire_sphere("sphere1", guik::FlatRed().translate(0.0f, 0.0f, 0.0f));
 
@@ -15,6 +20,15 @@ int main(int argc, char** argv) {
 
   std::this_thread::sleep_for(std::chrono::seconds(1));
   async_viewer->update_wire_sphere("sphere3", guik::FlatBlue().translate(4.0f, 0.0f, 0.0f));
+
+  // Register a UI callback, which will be called in the viewer thread.
+  async_viewer->register_ui_callback("ui_callback", [] {
+    if (ImGui::Button("Remove red sphere")) {
+      // Because this callback will be called in the viewer thread,
+      // it is safe to use the standard viewer interfaces.
+      guik::viewer()->remove_drawable("sphere1");
+    }
+  });
 
   // ```async_sub_viewer``` causes a syncronization with the visualization thread.
   // Do not call it frequently.

--- a/src/example/07_light_viewer_plots.cpp
+++ b/src/example/07_light_viewer_plots.cpp
@@ -1,0 +1,37 @@
+#include <implot.h>
+#include <guik/viewer/light_viewer.hpp>
+
+int main(int argc, char** argv) {
+  auto viewer = guik::viewer();
+
+  std::vector<double> xs;
+  std::vector<double> ys_sin;
+  for (double t = 0.0; t < 2.0 * M_PI; t += 0.1) {
+    xs.emplace_back(t);
+    ys_sin.emplace_back(std::sin(t));
+  }
+
+  // Basic plotting
+  viewer->setup_plot("curves_y", 1024, 256);
+  viewer->update_plot_line("curves_y", "sin", ys_sin);  // When only Y values are given, X values become index IDs
+  viewer->update_plot_stairs("curves_y", "sin_stairs", ys_sin);
+
+  viewer->setup_plot("curves_xy", 1024, 256);
+  viewer->update_plot_line("curves_xy", "sin", xs, ys_sin);
+  viewer->update_plot_stairs("curves_xy", "sin_stairs", xs, ys_sin);
+
+  std::vector<double> xs_circle;
+  std::vector<double> ys_circle;
+  for (double t = 0.0; t < 2.0 * M_PI; t += 0.1) {
+    xs_circle.emplace_back(std::cos(t));
+    ys_circle.emplace_back(std::sin(t));
+  }
+
+  // If a plot name contains "/", the string before the slash is recognized as a group name.
+  // Plots with the same group name are displayed in the same tab.
+  viewer->setup_plot("group02/circle", 1024, 1024, ImPlotFlags_Equal);
+  viewer->update_plot_line("group02/circle", "circle", xs_circle, ys_circle, ImPlotLineFlags_Loop);
+
+  viewer->spin();
+  return 0;
+}

--- a/src/guik/hovered_drawings.cpp
+++ b/src/guik/hovered_drawings.cpp
@@ -4,7 +4,7 @@
 namespace guik {
 
 struct HoveredDrawingsData {
-  std::shared_ptr<guik::LightViewerContext> context;
+  guik::LightViewerContext* context;
 
   std::vector<std::string> drawable_names;
   std::vector<std::shared_ptr<HoveredDrawing>> drawable_drawings;
@@ -13,7 +13,7 @@ struct HoveredDrawingsData {
   std::vector<std::shared_ptr<HoveredDrawing>> drawings;
 };
 
-HoveredDrawings::HoveredDrawings(const std::shared_ptr<guik::LightViewerContext>& context) : data(new HoveredDrawingsData{context}) {}
+HoveredDrawings::HoveredDrawings(guik::LightViewerContext* context) : data(new HoveredDrawingsData{context}) {}
 
 HoveredDrawings::~HoveredDrawings() {}
 

--- a/src/guik/viewer/async_light_viewer.cpp
+++ b/src/guik/viewer/async_light_viewer.cpp
@@ -1,0 +1,68 @@
+#include <guik/viewer/async_light_viewer.hpp>
+
+#include <atomic>
+
+namespace guik {
+
+std::unique_ptr<AsyncLightViewer> AsyncLightViewer::inst;
+
+AsyncLightViewer::AsyncLightViewer(const Eigen::Vector2i& size, bool background, const std::string& title) {
+  std::atomic_bool initiated = false;
+
+  kill_switch = false;
+  thread = std::thread([this, size, background, title, &initiated] {
+    auto viewer = guik::viewer(size, background, title);
+    context = viewer;
+
+    initiated = true;
+
+    while (!kill_switch && viewer->spin_once()) {
+    }
+    guik::destroy();
+  });
+
+  while (!initiated) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+AsyncLightViewer::~AsyncLightViewer() {
+  kill_switch = true;
+  thread.join();
+}
+
+AsyncLightViewer* AsyncLightViewer::instance(const Eigen::Vector2i& size, bool background, const std::string& title) {
+  if (!inst) {
+    inst.reset(new AsyncLightViewer(size, background, title));
+  }
+  return inst.get();
+}
+
+void AsyncLightViewer::destroy() {
+  inst.reset();
+}
+
+void AsyncLightViewer::wait() {
+  inst->thread.join();
+  inst.reset();
+}
+
+void AsyncLightViewer::invoke(const std::function<void()>& func) {
+  guik::viewer()->invoke(func);
+}
+
+void AsyncLightViewer::invoke_after_rendering(const std::function<void()>& func) {
+  guik::viewer()->invoke_after_rendering(func);
+}
+
+AsyncLightViewerContext AsyncLightViewer::async_sub_viewer(const std::string& context_name, const Eigen::Vector2i& canvas_size) {
+  std::shared_ptr<guik::LightViewerContext> sub_viewer;
+  guik::viewer()->invoke([&] { sub_viewer = guik::viewer()->sub_viewer(context_name, canvas_size); });
+  while (!sub_viewer) {
+    std::this_thread::sleep_for(std::chrono::nanoseconds(1));
+  }
+
+  return AsyncLightViewerContext(sub_viewer.get());
+}
+
+}  // namespace guik

--- a/src/guik/viewer/async_light_viewer.cpp
+++ b/src/guik/viewer/async_light_viewer.cpp
@@ -90,28 +90,39 @@ void AsyncLightViewer::update_plot(const std::string& plot_name, const std::stri
   guik::viewer()->invoke([=] { guik::viewer()->update_plot(plot_name, label, plot); });
 }
 
-void AsyncLightViewer::update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, size_t max_num_data) {
-  guik::viewer()->invoke([=] { guik::viewer()->update_plot_line(plot_name, label, ys, max_num_data); });
+void AsyncLightViewer::update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int line_flags, size_t max_num_data) {
+  guik::viewer()->invoke([=] { guik::viewer()->update_plot_line(plot_name, label, ys, line_flags, max_num_data); });
 }
 
-void AsyncLightViewer::update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, size_t max_num_data) {
-  guik::viewer()->invoke([=] { guik::viewer()->update_plot_line(plot_name, label, xs, ys, max_num_data); });
+void AsyncLightViewer::update_plot_line(
+  const std::string& plot_name,
+  const std::string& label,
+  const std::vector<double>& xs,
+  const std::vector<double>& ys,
+  int line_flags,
+  size_t max_num_data) {
+  guik::viewer()->invoke([=] { guik::viewer()->update_plot_line(plot_name, label, xs, ys, line_flags, max_num_data); });
 }
 
-void AsyncLightViewer::update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& ys) {
-  guik::viewer()->invoke([=] { guik::viewer()->update_plot_scatter(plot_name, label, ys); });
+void AsyncLightViewer::update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int scatter_flags) {
+  guik::viewer()->invoke([=] { guik::viewer()->update_plot_scatter(plot_name, label, ys, scatter_flags); });
 }
 
-void AsyncLightViewer::update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys) {
-  guik::viewer()->invoke([=] { guik::viewer()->update_plot_scatter(plot_name, label, xs, ys); });
+void AsyncLightViewer::update_plot_scatter(
+  const std::string& plot_name,
+  const std::string& label,
+  const std::vector<double>& xs,
+  const std::vector<double>& ys,
+  int scatter_flags) {
+  guik::viewer()->invoke([=] { guik::viewer()->update_plot_scatter(plot_name, label, xs, ys, scatter_flags); });
 }
 
-void AsyncLightViewer::update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& ys) {
-  guik::viewer()->invoke([=] { guik::viewer()->update_plot_stairs(plot_name, label, ys); });
+void AsyncLightViewer::update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int stairs_flags) {
+  guik::viewer()->invoke([=] { guik::viewer()->update_plot_stairs(plot_name, label, ys, stairs_flags); });
 }
 
-void AsyncLightViewer::update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys) {
-  guik::viewer()->invoke([=] { guik::viewer()->update_plot_stairs(plot_name, label, xs, ys); });
+void AsyncLightViewer::update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, int stairs_flags) {
+  guik::viewer()->invoke([=] { guik::viewer()->update_plot_stairs(plot_name, label, xs, ys, stairs_flags); });
 }
 
 AsyncLightViewerContext AsyncLightViewer::async_sub_viewer(const std::string& context_name, const Eigen::Vector2i& canvas_size) {

--- a/src/guik/viewer/async_light_viewer.cpp
+++ b/src/guik/viewer/async_light_viewer.cpp
@@ -55,6 +55,61 @@ void AsyncLightViewer::invoke_after_rendering(const std::function<void()>& func)
   guik::viewer()->invoke_after_rendering(func);
 }
 
+void AsyncLightViewer::clear_images() {
+  guik::viewer()->invoke([] { guik::viewer()->clear_images(); });
+}
+
+void AsyncLightViewer::remove_image(const std::string& name) {
+  guik::viewer()->invoke([=] { guik::viewer()->remove_image(name); });
+}
+
+void AsyncLightViewer::update_image(const std::string& name, int width, int height, const std::vector<unsigned char>& rgba_bytes, double scale, int order) {
+  guik::viewer()->invoke([=] {
+    auto texture = std::make_shared<glk::Texture>(Eigen::Vector2i(width, height), GL_RGBA, GL_RGBA, GL_UNSIGNED_BYTE, rgba_bytes.data());
+    guik::viewer()->update_image(name, texture, scale, order);
+  });
+}
+
+void AsyncLightViewer::clear_plots() {
+  guik::viewer()->invoke([] { guik::viewer()->clear_plots(); });
+}
+
+void AsyncLightViewer::remove_plot(const std::string& plot_name, const std::string& label) {
+  guik::viewer()->invoke([=] { guik::viewer()->remove_plot(plot_name, label); });
+}
+
+void AsyncLightViewer::setup_plot(const std::string& plot_name, int width, int height, int plot_flags, int x_flags, int y_flags, int order) {
+  guik::viewer()->invoke([=] { guik::viewer()->setup_plot(plot_name, width, height, plot_flags, x_flags, y_flags, order); });
+}
+
+void AsyncLightViewer::update_plot(const std::string& plot_name, const std::string& label, const std::shared_ptr<const PlotData>& plot) {
+  guik::viewer()->invoke([=] { guik::viewer()->update_plot(plot_name, label, plot); });
+}
+
+void AsyncLightViewer::update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, size_t max_num_data) {
+  guik::viewer()->invoke([=] { guik::viewer()->update_plot_line(plot_name, label, ys, max_num_data); });
+}
+
+void AsyncLightViewer::update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, size_t max_num_data) {
+  guik::viewer()->invoke([=] { guik::viewer()->update_plot_line(plot_name, label, xs, ys, max_num_data); });
+}
+
+void AsyncLightViewer::update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& ys) {
+  guik::viewer()->invoke([=] { guik::viewer()->update_plot_scatter(plot_name, label, ys); });
+}
+
+void AsyncLightViewer::update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys) {
+  guik::viewer()->invoke([=] { guik::viewer()->update_plot_scatter(plot_name, label, xs, ys); });
+}
+
+void AsyncLightViewer::update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& ys) {
+  guik::viewer()->invoke([=] { guik::viewer()->update_plot_stairs(plot_name, label, ys); });
+}
+
+void AsyncLightViewer::update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys) {
+  guik::viewer()->invoke([=] { guik::viewer()->update_plot_stairs(plot_name, label, xs, ys); });
+}
+
 AsyncLightViewerContext AsyncLightViewer::async_sub_viewer(const std::string& context_name, const Eigen::Vector2i& canvas_size) {
   std::shared_ptr<guik::LightViewerContext> sub_viewer;
   guik::viewer()->invoke([&] { sub_viewer = guik::viewer()->sub_viewer(context_name, canvas_size); });

--- a/src/guik/viewer/async_light_viewer.cpp
+++ b/src/guik/viewer/async_light_viewer.cpp
@@ -28,7 +28,9 @@ AsyncLightViewer::AsyncLightViewer(const Eigen::Vector2i& size, bool background,
 
 AsyncLightViewer::~AsyncLightViewer() {
   kill_switch = true;
-  thread.join();
+  if (thread.joinable()) {
+    thread.join();
+  }
 }
 
 AsyncLightViewer* AsyncLightViewer::instance(const Eigen::Vector2i& size, bool background, const std::string& title) {
@@ -43,7 +45,9 @@ void AsyncLightViewer::destroy() {
 }
 
 void AsyncLightViewer::wait() {
-  inst->thread.join();
+  if (inst->thread.joinable()) {
+    inst->thread.join();
+  }
   inst.reset();
 }
 

--- a/src/guik/viewer/async_light_viewer_context.cpp
+++ b/src/guik/viewer/async_light_viewer_context.cpp
@@ -1,0 +1,165 @@
+#include <guik/viewer/async_light_viewer_context.hpp>
+
+#include <glk/thin_lines.hpp>
+#include <glk/pointcloud_buffer.hpp>
+#include <glk/normal_distributions.hpp>
+#include <glk/primitives/primitives.hpp>
+#include <guik/viewer/light_viewer.hpp>
+
+namespace guik {
+
+AsyncLightViewerContext::AsyncLightViewerContext() {}
+
+AsyncLightViewerContext::AsyncLightViewerContext(LightViewerContext* context) : context(context) {}
+
+AsyncLightViewerContext::~AsyncLightViewerContext() {}
+
+void AsyncLightViewerContext::clear() {
+  guik::viewer()->invoke([=] { context->clear(); });
+}
+
+void AsyncLightViewerContext::clear_text() {
+  guik::viewer()->invoke([=] { context->clear_text(); });
+}
+
+void AsyncLightViewerContext::append_text(const std::string& text) {
+  guik::viewer()->invoke([=] { context->append_text(text); });
+}
+
+void AsyncLightViewerContext::set_draw_xy_grid(bool draw_xy_grid) {
+  guik::viewer()->invoke([=] { context->set_draw_xy_grid(draw_xy_grid); });
+}
+
+void AsyncLightViewerContext::set_colormap(glk::COLORMAP colormap) {
+  guik::viewer()->invoke([=] { context->set_colormap(colormap); });
+}
+
+void AsyncLightViewerContext::clear_drawables() {
+  guik::viewer()->invoke([=] { context->clear_drawables(); });
+}
+void AsyncLightViewerContext::clear_drawables(const std::function<bool(const std::string&)>& fn) {
+  guik::viewer()->invoke([=] { context->clear_drawables(fn); });
+}
+
+void AsyncLightViewerContext::remove_drawable(const std::string& name) {
+  guik::viewer()->invoke([=] { context->remove_drawable(name); });
+}
+
+void AsyncLightViewerContext::remove_drawable(const std::regex& regex) {
+  guik::viewer()->invoke([=] { context->remove_drawable(regex); });
+}
+
+void AsyncLightViewerContext::reset_center() {
+  guik::viewer()->invoke([=] { context->reset_center(); });
+}
+
+void AsyncLightViewerContext::lookat(const Eigen::Vector3f& pt) {
+  guik::viewer()->invoke([=] { context->lookat(pt); });
+}
+
+void AsyncLightViewerContext::use_orbit_camera_control(double distance, double theta, double phi) {
+  guik::viewer()->invoke([=] { context->use_orbit_camera_control(distance, theta, phi); });
+}
+
+void AsyncLightViewerContext::use_orbit_camera_control_xz(double distance, double theta, double phi) {
+  guik::viewer()->invoke([=] { context->use_orbit_camera_control_xz(distance, theta, phi); });
+}
+
+void AsyncLightViewerContext::use_topdown_camera_control(double distance, double theta) {
+  guik::viewer()->invoke([=] { context->use_topdown_camera_control(distance, theta); });
+}
+
+void AsyncLightViewerContext::use_arcball_camera_control(double distance, double theta, double phi) {
+  guik::viewer()->invoke([=] { context->use_arcball_camera_control(distance, theta, phi); });
+}
+
+// PointCloudBuffer
+void AsyncLightViewerContext::update_points(const std::string& name, const float* data, int stride, int num_points, const ShaderSetting& shader_setting) {
+  std::vector<float> buffer(data, data + stride / sizeof(float) * num_points);
+
+  guik::viewer()->invoke([=] {
+    auto cloud_buffer = std::make_shared<glk::PointCloudBuffer>(buffer.data(), stride, num_points);
+    context->update_drawable(name, cloud_buffer, shader_setting);
+  });
+}
+
+template <typename Scalar, int Dim>
+void AsyncLightViewerContext::update_normal_dists(
+  const std::string& name,
+  const Eigen::Matrix<Scalar, Dim, 1>* points,
+  const Eigen::Matrix<Scalar, Dim, Dim>* covs,
+  int num_points,
+  float scale,
+  const ShaderSetting& shader_setting) {
+  std::vector<Eigen::Matrix<Scalar, Dim, 1>> points_buffer(points, points + num_points);
+  std::vector<Eigen::Matrix<Scalar, Dim, Dim>> covs_buffer(covs, covs + num_points);
+  guik::viewer()->invoke(
+    [=] { context->update_drawable(name, std::make_shared<glk::NormalDistributions>(points_buffer.data(), covs_buffer.data(), num_points, scale), shader_setting); });
+}
+
+template void
+AsyncLightViewerContext::update_normal_dists(const std::string&, const Eigen::Matrix<float, 3, 1>*, const Eigen::Matrix<float, 3, 3>*, int, float, const ShaderSetting&);
+template void
+AsyncLightViewerContext::update_normal_dists(const std::string&, const Eigen::Matrix<float, 4, 1>*, const Eigen::Matrix<float, 4, 4>*, int, float, const ShaderSetting&);
+template void
+AsyncLightViewerContext::update_normal_dists(const std::string&, const Eigen::Matrix<double, 3, 1>*, const Eigen::Matrix<double, 3, 3>*, int, float, const ShaderSetting&);
+template void
+AsyncLightViewerContext::update_normal_dists(const std::string&, const Eigen::Matrix<double, 4, 1>*, const Eigen::Matrix<double, 4, 4>*, int, float, const ShaderSetting&);
+
+// ThinLines
+void AsyncLightViewerContext::update_thin_lines(
+  const std::string& name,
+  const float* vertices,
+  const float* colors,
+  int num_vertices,
+  const unsigned int* indices,
+  int num_indices,
+  bool line_strip,
+  const ShaderSetting& shader_setting) {
+  //
+  std::vector<float> vertices_buffer(vertices, vertices + 3 * num_vertices);
+  std::vector<float> colors_buffer;
+  if (colors) {
+    colors_buffer.assign(colors, colors + 4 * num_vertices);
+  }
+  std::vector<unsigned int> indices_buffer(indices, indices + num_indices);
+
+  guik::viewer()->invoke([=] {
+    auto thin_lines = std::make_shared<glk::ThinLines>(vertices_buffer.data(), colors_buffer.data(), num_vertices, indices_buffer.data(), num_indices, line_strip);
+    context->update_drawable(name, thin_lines, shader_setting);
+  });
+}
+
+// Primitives
+void AsyncLightViewerContext::update_icosahedron(const std::string& name, const ShaderSetting& shader_setting) {
+  guik::viewer()->invoke([=] { context->update_drawable(name, glk::Primitives::icosahedron(), shader_setting); });
+}
+void AsyncLightViewerContext::update_sphere(const std::string& name, const ShaderSetting& shader_setting) {
+  guik::viewer()->invoke([=] { context->update_drawable(name, glk::Primitives::sphere(), shader_setting); });
+}
+void AsyncLightViewerContext::update_cube(const std::string& name, const ShaderSetting& shader_setting) {
+  guik::viewer()->invoke([=] { context->update_drawable(name, glk::Primitives::cube(), shader_setting); });
+}
+void AsyncLightViewerContext::update_cone(const std::string& name, const ShaderSetting& shader_setting) {
+  guik::viewer()->invoke([=] { context->update_drawable(name, glk::Primitives::cone(), shader_setting); });
+}
+void AsyncLightViewerContext::update_coord(const std::string& name, const ShaderSetting& shader_setting) {
+  guik::viewer()->invoke([=] { context->update_drawable(name, glk::Primitives::coordinate_system(), shader_setting); });
+}
+void AsyncLightViewerContext::update_wire_icosahedron(const std::string& name, const ShaderSetting& shader_setting) {
+  guik::viewer()->invoke([=] { context->update_drawable(name, glk::Primitives::wire_icosahedron(), shader_setting); });
+}
+void AsyncLightViewerContext::update_wire_sphere(const std::string& name, const ShaderSetting& shader_setting) {
+  guik::viewer()->invoke([=] { context->update_drawable(name, glk::Primitives::wire_sphere(), shader_setting); });
+}
+void AsyncLightViewerContext::update_wire_cube(const std::string& name, const ShaderSetting& shader_setting) {
+  guik::viewer()->invoke([=] { context->update_drawable(name, glk::Primitives::wire_cube(), shader_setting); });
+}
+void AsyncLightViewerContext::update_wire_cone(const std::string& name, const ShaderSetting& shader_setting) {
+  guik::viewer()->invoke([=] { context->update_drawable(name, glk::Primitives::wire_cone(), shader_setting); });
+}
+void AsyncLightViewerContext::update_wire_frustum(const std::string& name, const ShaderSetting& shader_setting) {
+  guik::viewer()->invoke([=] { context->update_drawable(name, glk::Primitives::wire_frustum(), shader_setting); });
+}
+
+}  // namespace guik

--- a/src/guik/viewer/async_light_viewer_context.cpp
+++ b/src/guik/viewer/async_light_viewer_context.cpp
@@ -26,6 +26,10 @@ void AsyncLightViewerContext::append_text(const std::string& text) {
   guik::viewer()->invoke([=] { context->append_text(text); });
 }
 
+void AsyncLightViewerContext::register_ui_callback(const std::string& name, const std::function<void()>& callback) {
+  guik::viewer()->invoke([=] { context->register_ui_callback(name, callback); });
+}
+
 void AsyncLightViewerContext::set_draw_xy_grid(bool draw_xy_grid) {
   guik::viewer()->invoke([=] { context->set_draw_xy_grid(draw_xy_grid); });
 }

--- a/src/guik/viewer/light_viewer.cpp
+++ b/src/guik/viewer/light_viewer.cpp
@@ -18,7 +18,28 @@
 
 namespace guik {
 
-std::shared_ptr<LightViewer> LightViewer::inst;
+std::unique_ptr<LightViewer> LightViewer::inst;
+
+LightViewer* LightViewer::instance(const Eigen::Vector2i& size, bool background, const std::string& title) {
+  if (!inst) {
+    Eigen::Vector2i init_size = (size.array() > 0).all() ? size : Eigen::Vector2i(1920, 1080);
+    inst.reset(new LightViewer());
+    inst->init(init_size, "#version 330", background, title);
+  } else {
+    if ((size.array() > 0).all() && inst->window_size() != size) {
+      inst->resize(size);
+    }
+  }
+
+  return inst.get();
+}
+
+void LightViewer::destroy() {
+  if (inst) {
+    inst->clear();
+    inst.reset();
+  }
+}
 
 LightViewer::LightViewer() : Application(), LightViewerContext("main"), max_texts_size(32) {}
 
@@ -29,7 +50,7 @@ bool LightViewer::init(const Eigen::Vector2i& size, const char* glsl_version, bo
   // GL::Renderer::setClearColor(0x474747_rgbf); // lightwave
   // GL::Renderer::setClearColor(0x3a3a3a_rgbf); // blender
 
-  if(!LightViewerContext::init_canvas(size)) {
+  if (!LightViewerContext::init_canvas(size)) {
     close();
     return false;
   }
@@ -47,7 +68,7 @@ void LightViewer::framebuffer_size_callback(const Eigen::Vector2i& size) {
 
 void LightViewer::draw_ui() {
   std::unique_lock<std::mutex> lock(invoke_requests_mutex);
-  while(!invoke_requests.empty()) {
+  while (!invoke_requests.empty()) {
     invoke_requests.front()();
     invoke_requests.pop_front();
   }
@@ -63,24 +84,24 @@ void LightViewer::draw_ui() {
   }
 
   // viewer UI
-  if(viewer_ui) {
-    if(!viewer_ui->draw_ui()) {
+  if (viewer_ui) {
+    if (!viewer_ui->draw_ui()) {
       viewer_ui.reset();
     }
-  } else if(ImGui::GetIO().KeyCtrl && ImGui::GetIO().KeysDown[GLFW_KEY_M]) {
+  } else if (ImGui::GetIO().KeyCtrl && ImGui::GetIO().KeysDown[GLFW_KEY_M]) {
     viewer_ui.reset(new ViewerUI(this));
   }
 
   // point scale
   bool decrease_point_size = ImGui::GetIO().KeysDown[GLFW_KEY_MINUS];
   bool increase_point_size = ImGui::GetIO().KeyShift && ImGui::GetIO().KeysDown[GLFW_KEY_SEMICOLON];
-  if(decrease_point_size || increase_point_size) {
+  if (decrease_point_size || increase_point_size) {
     auto point_size = global_shader_setting.get<float>("point_size");
-    if(!point_size) {
+    if (!point_size) {
       point_size = 10.0f;
     }
 
-    if(decrease_point_size) {
+    if (decrease_point_size) {
       *point_size = point_size.get() - ImGui::GetIO().DeltaTime * 10.0f;
     } else {
       *point_size = point_size.get() + ImGui::GetIO().DeltaTime * 10.0f;
@@ -92,25 +113,24 @@ void LightViewer::draw_ui() {
   }
 
   // screen shot
-  if(ImGui::GetIO().KeysDown[GLFW_KEY_J]) {
+  if (ImGui::GetIO().KeysDown[GLFW_KEY_J]) {
     invoke_after_rendering([this] {
       auto bytes = canvas->frame_buffer->color().read_pixels<unsigned char>(GL_RGBA, GL_UNSIGNED_BYTE);
       std::vector<unsigned char> flipped(bytes.size(), 255);
 
       Eigen::Vector2i size = canvas->frame_buffer->color().size();
-      for(int y = 0; y < size[1]; y++) {
+      for (int y = 0; y < size[1]; y++) {
         int y_ = size[1] - y - 1;
-        for(int x = 0; x < size[0]; x++) {
-          for(int k = 0; k < 3; k++) {
+        for (int x = 0; x < size[0]; x++) {
+          for (int k = 0; k < 3; k++) {
             flipped[(y_ * size[0] + x) * 4 + k] = bytes[(y * size[0] + x) * 4 + k];
           }
         }
       }
 
-      double time =
-          std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count() / 1e9;
+      double time = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now().time_since_epoch()).count() / 1e9;
       std::string filename = (boost::format("/tmp/ss_%.6f.png") % time).str();
-      if(glk::save_png(filename, canvas->size[0], canvas->size[1], flipped)) {
+      if (glk::save_png(filename, canvas->size[0], canvas->size[1], flipped)) {
         std::cout << "screen shot saved:" << filename << std::endl;
       } else {
         std::cout << "failed to save screen shot" << std::endl;
@@ -118,8 +138,8 @@ void LightViewer::draw_ui() {
     });
   }
 
-  if(info_window) {
-    if(!info_window->draw_ui()) {
+  if (info_window) {
+    if (!info_window->draw_ui()) {
       info_window.reset();
     }
   }
@@ -131,26 +151,29 @@ void LightViewer::draw_ui() {
     std::vector<std::string>(texts.begin(), texts.end()).swap(texts_);
   }
 
-  if(!texts_.empty()) {
-    ImGui::Begin("texts", nullptr, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav);
-    for(int i = std::max<int>(0, texts_.size() - max_texts_size); i < texts_.size(); i++) {
+  if (!texts_.empty()) {
+    ImGui::Begin(
+      "texts",
+      nullptr,
+      ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav);
+    for (int i = std::max<int>(0, texts_.size() - max_texts_size); i < texts_.size(); i++) {
       const auto& text = texts_[i];
       ImGui::Text("%s", text.c_str());
     }
 
-    if(ImGui::Button("clear")) {
+    if (ImGui::Button("clear")) {
       clear_text();
     }
     ImGui::End();
   }
 
   // images
-  if(!images.empty()) {
+  if (!images.empty()) {
     ImGui::Begin("images", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
 
     images_in_rendering.clear();
     std::unordered_map<std::string, std::vector<std::string>> groups;
-    for(const auto& image: images) {
+    for (const auto& image : images) {
       const size_t separator_loc = image.first.find_first_of('/');
       const std::string group = separator_loc == std::string::npos ? "default" : image.first.substr(0, separator_loc);
       groups[group].push_back(image.first);
@@ -159,14 +182,14 @@ void LightViewer::draw_ui() {
 
     const bool grouping = groups.size() > 1;
 
-    if(grouping) {
+    if (grouping) {
       ImGuiTabBarFlags tab_bar_flags = ImGuiTabBarFlags_None;
       ImGui::BeginTabBar("imagetab", tab_bar_flags);
     }
 
-    for(auto& group: groups) {
-      if(grouping) {
-        if(!ImGui::BeginTabItem(group.first.c_str())) {
+    for (auto& group : groups) {
+      if (grouping) {
+        if (!ImGui::BeginTabItem(group.first.c_str())) {
           continue;
         }
       }
@@ -175,7 +198,7 @@ void LightViewer::draw_ui() {
       auto& image_names = group.second;
       std::sort(image_names.begin(), image_names.end());
 
-      for(const auto& name: image_names) {
+      for (const auto& name : image_names) {
         const auto& image = images[name];
         const double scale = image.first;
         const auto& texture = image.second;
@@ -186,12 +209,12 @@ void LightViewer::draw_ui() {
         ImGui::Image(reinterpret_cast<void*>(texture->id()), ImVec2(size[0], size[1]), ImVec2(0, 0), ImVec2(1, 1));
       }
 
-      if(grouping) {
+      if (grouping) {
         ImGui::EndTabItem();
       }
     }
 
-    if(grouping) {
+    if (grouping) {
       ImGui::EndTabBar();
     }
 
@@ -199,11 +222,11 @@ void LightViewer::draw_ui() {
   }
 
   // mouse control
-  if(!ImGui::GetIO().WantCaptureMouse) {
+  if (!ImGui::GetIO().WantCaptureMouse) {
     canvas->mouse_control();
   }
 
-  for(const auto& context : sub_contexts) {
+  for (const auto& context : sub_contexts) {
     context.second->draw_gl();
     context.second->draw_ui();
   }
@@ -214,7 +237,7 @@ void LightViewer::draw_gl() {
   canvas->render_to_screen();
 
   std::unique_lock<std::mutex> lock(post_render_invoke_requests_mutex);
-  while(!post_render_invoke_requests.empty()) {
+  while (!post_render_invoke_requests.empty()) {
     post_render_invoke_requests.front()();
     post_render_invoke_requests.pop_front();
   }
@@ -257,7 +280,7 @@ void LightViewer::clear_images() {
 
 void LightViewer::remove_image(const std::string& name) {
   auto found = images.find(name);
-  if(found != images.end()) {
+  if (found != images.end()) {
     images.erase(found);
   }
 }
@@ -268,7 +291,7 @@ void LightViewer::update_image(const std::string& name, const std::shared_ptr<gl
     return;
   }
 
-  if(scale < 0.0) {
+  if (scale < 0.0) {
     double scale_x = 640.0 / image->size()[0];
     double scale_y = 480.0 / image->size()[1];
     scale = std::min(scale_x, scale_y);
@@ -282,8 +305,8 @@ bool LightViewer::spin_until_click() {
 
   register_ui_callback("kill_switch", [&]() { kill_switch = ImGui::Button("break"); });
 
-  while(!kill_switch) {
-    if(!spin_once()) {
+  while (!kill_switch) {
+    if (!spin_once()) {
       return false;
     }
   }
@@ -299,7 +322,7 @@ bool LightViewer::toggle_spin_once() {
   register_ui_callback("kill_switch", [&]() { ImGui::Checkbox("break", &stop); });
 
   do {
-    if(!spin_once()) {
+    if (!spin_once()) {
       return false;
     }
   } while (stop);
@@ -310,7 +333,7 @@ bool LightViewer::toggle_spin_once() {
 }
 
 void LightViewer::register_ui_callback(const std::string& name, const std::function<void()>& callback) {
-  if(!callback) {
+  if (!callback) {
     ui_callbacks.erase(name);
     return;
   }
@@ -319,13 +342,13 @@ void LightViewer::register_ui_callback(const std::string& name, const std::funct
 }
 
 void LightViewer::show_viewer_ui() {
-  if(viewer_ui == nullptr) {
+  if (viewer_ui == nullptr) {
     viewer_ui.reset(new ViewerUI(this));
   }
 }
 
 void LightViewer::show_info_window() {
-  if(info_window == nullptr) {
+  if (info_window == nullptr) {
     info_window.reset(new InfoWindow());
   }
 }
@@ -344,14 +367,14 @@ std::shared_ptr<LightViewerContext> LightViewer::sub_viewer(const std::string& c
   using namespace glk::console;
 
   auto found = sub_contexts.find(context_name);
-  if(found == sub_contexts.end()) {
+  if (found == sub_contexts.end()) {
     Eigen::Vector2i init_canvas_size = canvas_size;
-    if(canvas_size[0] <= 0 || canvas_size[1] <= 0) {
+    if (canvas_size[0] <= 0 || canvas_size[1] <= 0) {
       init_canvas_size = Eigen::Vector2i(512, 512);
     }
 
     std::shared_ptr<LightViewerContext> context(new LightViewerContext(context_name));
-    if(!context->init_canvas(init_canvas_size)) {
+    if (!context->init_canvas(init_canvas_size)) {
       std::cerr << bold_red << "error: failed to create sub viewer context!!" << reset << std::endl;
       return nullptr;
     }
@@ -360,8 +383,8 @@ std::shared_ptr<LightViewerContext> LightViewer::sub_viewer(const std::string& c
     return context;
   }
 
-  if((canvas_size.array() > 0).all() && found->second->canvas_size() != canvas_size) {
-    if(!found->second->init_canvas(canvas_size)) {
+  if ((canvas_size.array() > 0).all() && found->second->canvas_size() != canvas_size) {
+    if (!found->second->init_canvas(canvas_size)) {
       std::cerr << bold_red << "error: failed to resize the canvas of " << context_name << "!!" << reset << std::endl;
       close();
     }
@@ -395,7 +418,7 @@ std::vector<float> LightViewer::read_depth_buffer(bool real_scale) {
   for (int y = 0; y < size[1]; y++) {
     int y_ = size[1] - y - 1;
     for (int x = 0; x < size[0]; x++) {
-        flipped[y_ * size[0] + x] = floats[y * size[0] + x];
+      flipped[y_ * size[0] + x] = floats[y * size[0] + x];
     }
   }
 

--- a/src/guik/viewer/light_viewer.cpp
+++ b/src/guik/viewer/light_viewer.cpp
@@ -358,7 +358,7 @@ void LightViewer::update_image(const std::string& name, const std::shared_ptr<gl
     scale = std::min(scale_x, scale_y);
   }
 
-  images[name] = std::make_tuple(scale, image, order >= 0 ? order  : 8192 + images.size());
+  images[name] = std::make_tuple(scale, image, order >= 0 ? order : 8192 + images.size());
 }
 
 void LightViewer::clear_plots() {
@@ -401,19 +401,26 @@ void LightViewer::update_plot(const std::string& plot_name, const std::string& l
   }
 }
 
-void LightViewer::update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, size_t max_num_data) {
+void LightViewer::update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int line_flags, size_t max_num_data) {
   std::vector<double> xs(ys.size());
   std::iota(xs.begin(), xs.end(), 0.0);
-  update_plot_line(plot_name, label, xs, ys, max_num_data);
+  update_plot_line(plot_name, label, xs, ys, line_flags, max_num_data);
 }
 
-void LightViewer::update_plot_line(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, size_t max_num_data) {
+void LightViewer::update_plot_line(
+  const std::string& plot_name,
+  const std::string& label,
+  const std::vector<double>& xs,
+  const std::vector<double>& ys,
+  int line_flags,
+  size_t max_num_data) {
   if (xs.size() != ys.size()) {
     std::cerr << "warning: the length of xs must be the same as the length of ys (" << xs.size() << " vs " << ys.size() << ")" << std::endl;
     return;
   }
 
   auto p = std::make_shared<LinePlotData>(label);
+  p->line_flags = line_flags;
 
   if (xs.size() <= max_num_data) {
     p->xs = xs;
@@ -434,28 +441,30 @@ void LightViewer::update_plot_line(const std::string& plot_name, const std::stri
   update_plot(plot_name, label, p);
 }
 
-void LightViewer::update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& ys) {
+void LightViewer::update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int scatter_flags) {
   std::vector<double> xs(ys.size());
   std::iota(xs.begin(), xs.end(), 0.0);
-  update_plot_scatter(plot_name, label, xs, ys);
+  update_plot_scatter(plot_name, label, xs, ys, scatter_flags);
 }
 
-void LightViewer::update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys) {
+void LightViewer::update_plot_scatter(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, int scatter_flags) {
   auto p = std::make_shared<ScatterPlotData>(label);
+  p->scatter_flags = scatter_flags;
   p->xs = xs;
   p->ys = ys;
 
   update_plot(plot_name, label, p);
 }
 
-void LightViewer::update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& ys) {
+void LightViewer::update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& ys, int stairs_flags) {
   std::vector<double> xs(ys.size());
   std::iota(xs.begin(), xs.end(), 0.0);
-  update_plot_stairs(plot_name, label, xs, ys);
+  update_plot_stairs(plot_name, label, xs, ys, stairs_flags);
 }
 
-void LightViewer::update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys) {
+void LightViewer::update_plot_stairs(const std::string& plot_name, const std::string& label, const std::vector<double>& xs, const std::vector<double>& ys, int stairs_flags) {
   auto p = std::make_shared<StairsPlotData>(label);
+  p->stairs_flags = stairs_flags;
   p->xs = xs;
   p->ys = ys;
 

--- a/src/guik/viewer/light_viewer_context.cpp
+++ b/src/guik/viewer/light_viewer_context.cpp
@@ -6,6 +6,7 @@
 #include <glk/primitives/primitives.hpp>
 
 #include <guik/viewer/light_viewer.hpp>
+#include <guik/viewer/async_light_viewer_context.hpp>
 #include <guik/camera/orbit_camera_control_xy.hpp>
 #include <guik/camera/orbit_camera_control_xz.hpp>
 #include <guik/camera/topdown_camera_control.hpp>
@@ -411,6 +412,10 @@ std::optional<Eigen::Vector3f> LightViewerContext::pick_point(int button, int wi
   }
 
   return unproject({io.MousePos.x, io.MousePos.y}, depth);
+}
+
+AsyncLightViewerContext LightViewerContext::async() {
+  return AsyncLightViewerContext(this);
 }
 
 }  // namespace guik

--- a/src/guik/viewer/plot_data.cpp
+++ b/src/guik/viewer/plot_data.cpp
@@ -1,0 +1,19 @@
+#include <guik/viewer/plot_data.hpp>
+
+#include <implot.h>
+
+namespace guik {
+
+void LinePlotData::plot() const {
+  ImPlot::PlotLine(label.c_str(), xs.data(), ys.data(), xs.size(), line_flags);
+}
+
+void ScatterPlotData::plot() const {
+  ImPlot::PlotScatter(label.c_str(), xs.data(), ys.data(), xs.size(), scatter_flags);
+}
+
+void StairsPlotData::plot() const {
+  ImPlot::PlotStairs(label.c_str(), xs.data(), ys.data(), xs.size(), stairs_flags);
+}
+
+}  // namespace guik

--- a/src/python/guik.cpp
+++ b/src/python/guik.cpp
@@ -13,7 +13,7 @@
 
 namespace py = pybind11;
 
-std::shared_ptr<guik::LightViewer> instance(const Eigen::Vector2i& size, bool background, const std::string& title) {
+guik::LightViewer* instance(const Eigen::Vector2i& size, bool background, const std::string& title) {
   static bool is_first = true;
   if (is_first) {
     py::gil_scoped_acquire acquire;
@@ -24,7 +24,7 @@ std::shared_ptr<guik::LightViewer> instance(const Eigen::Vector2i& size, bool ba
     is_first = false;
   }
 
-  static std::shared_ptr<guik::LightViewer> inst = guik::LightViewer::instance(size, background, title);
+  static guik::LightViewer* inst = guik::LightViewer::instance(size, background, title);
   return inst;
 }
 
@@ -163,7 +163,7 @@ void define_guik(py::module_& m) {
   py::class_<guik::ProjectionControl, std::shared_ptr<guik::ProjectionControl>>(guik_, "ProjectionControl");
 
   // LightViewerContext
-  py::class_<guik::LightViewerContext, std::shared_ptr<guik::LightViewerContext>>(guik_, "LightViewerContext")
+  py::class_<guik::LightViewerContext, std::unique_ptr<guik::LightViewerContext, py::nodelete>>(guik_, "LightViewerContext")
     .def("set_size", &guik::LightViewerContext::set_size)
     .def("set_clear_color", &guik::LightViewerContext::set_clear_color)
     .def("set_pos", &guik::LightViewerContext::set_pos, "", py::arg("pos"), py::arg("cond") = static_cast<int>(ImGuiCond_FirstUseEver), py::arg("flags") = 0)
@@ -204,7 +204,7 @@ void define_guik(py::module_& m) {
     .def("set_projection_control", &guik::LightViewerContext::set_projection_control, "");
 
   // LightViewer
-  py::class_<guik::LightViewer, guik::LightViewerContext, std::shared_ptr<guik::LightViewer>>(guik_, "LightViewer")
+  py::class_<guik::LightViewer, guik::LightViewerContext, std::unique_ptr<guik::LightViewer, py::nodelete>>(guik_, "LightViewer")
     .def_static(
       "instance",
       [](const Eigen::Vector2i& size, bool background, const std::string& title) { return instance(size, background, title); },

--- a/src/python/guik.cpp
+++ b/src/python/guik.cpp
@@ -245,7 +245,7 @@ void define_guik(py::module_& m) {
 
     .def("clear_images", &guik::LightViewer::clear_images)
     .def("remove_image", &guik::LightViewer::remove_image)
-    .def("update_image", &guik::LightViewer::update_image, py::arg("name"), py::arg("image"), py::arg("scale") = -1.0)
+    .def("update_image", &guik::LightViewer::update_image, py::arg("name"), py::arg("image"), py::arg("scale") = -1.0, py::arg("order") = -1)
 
     .def(
       "update_points",

--- a/src/python/guik.cpp
+++ b/src/python/guik.cpp
@@ -10,11 +10,13 @@
 #include <guik/recent_files.hpp>
 #include <guik/model_control.hpp>
 #include <guik/viewer/light_viewer.hpp>
+#include <guik/viewer/async_light_viewer.hpp>
 
 namespace py = pybind11;
 
+static bool is_first = true;
+
 guik::LightViewer* instance(const Eigen::Vector2i& size, bool background, const std::string& title) {
-  static bool is_first = true;
   if (is_first) {
     py::gil_scoped_acquire acquire;
     py::object pyridescence = py::module::import("pyridescence");
@@ -26,6 +28,19 @@ guik::LightViewer* instance(const Eigen::Vector2i& size, bool background, const 
 
   static guik::LightViewer* inst = guik::LightViewer::instance(size, background, title);
   return inst;
+}
+
+guik::AsyncLightViewer* async_instance(const Eigen::Vector2i& size, bool background, const std::string& title) {
+  if (is_first) {
+    py::gil_scoped_acquire acquire;
+    py::object pyridescence = py::module::import("pyridescence");
+    boost::filesystem::path path(pyridescence.attr("__file__").cast<std::string>());
+
+    glk::set_data_path(path.parent_path().string() + "/data");
+    is_first = false;
+  }
+
+  return guik::AsyncLightViewer::instance(size, background, title);
 }
 
 void define_guik(py::module_& m) {
@@ -211,12 +226,13 @@ void define_guik(py::module_& m) {
       py::arg("size") = Eigen::Vector2i(1920, 1080),
       py::arg("background") = false,
       py::arg("title") = "screen")
-    .def("sub_viewer", [](guik::LightViewer& viewer, const std::string& name) { return viewer.sub_viewer(name); })
     .def(
       "sub_viewer",
       [](guik::LightViewer& viewer, const std::string& name, const std::tuple<int, int>& size) {
         return viewer.sub_viewer(name, Eigen::Vector2i(std::get<0>(size), std::get<1>(size)));
-      })
+      },
+      py::arg("name"),
+      py::arg("size") = std::make_tuple(-1, -1))
 
     .def("close", &guik::LightViewer::close)
     .def("spin", &guik::LightViewer::spin)
@@ -230,6 +246,16 @@ void define_guik(py::module_& m) {
     .def("clear_images", &guik::LightViewer::clear_images)
     .def("remove_image", &guik::LightViewer::remove_image)
     .def("update_image", &guik::LightViewer::update_image, py::arg("name"), py::arg("image"), py::arg("scale") = -1.0)
+
+    .def(
+      "update_points",
+      [](guik::LightViewer& context, const std::string& name, const Eigen::Matrix<float, -1, -1, Eigen::RowMajor>& points, const guik::ShaderSetting& shader_setting) {
+        if (points.cols() != 3 && points.cols() != 4) {
+          std::cerr << "warning: points must be Nx3 or Nx4" << std::endl;
+          return;
+        }
+        context.update_points(name, points.data(), sizeof(float) * points.cols(), points.rows(), shader_setting);
+      })
 
     // LightViewerContext methods
     .def("clear", &guik::LightViewer::clear)
@@ -264,6 +290,73 @@ void define_guik(py::module_& m) {
     .def("pick_depth", &guik::LightViewer::pick_depth, py::arg("p"), py::arg("window") = 2)
     .def("unproject", &guik::LightViewer::unproject, py::arg("p"), py::arg("depth"));
 
+  // AsyncLightViewerContext
+  py::class_<guik::AsyncLightViewerContext, std::shared_ptr<guik::AsyncLightViewerContext>>(guik_, "AsyncLightViewerContext")
+    .def("clear", &guik::AsyncLightViewerContext::clear)
+    .def("clear_text", &guik::AsyncLightViewerContext::clear_text)
+    .def("append_text", &guik::AsyncLightViewerContext::append_text)
+    .def(
+      "remove_drawable",
+      [](guik::AsyncLightViewerContext& context, const std::string& pattern, bool regex) {
+        if (regex) {
+          context.remove_drawable(std::regex(pattern));
+        } else {
+          context.remove_drawable(pattern);
+        }
+      },
+      py::arg("pattern"),
+      py::arg("regex") = false)
+    .def("reset_center", &guik::AsyncLightViewerContext::reset_center)
+    .def("lookat", &guik::AsyncLightViewerContext::lookat)
+    .def("set_draw_xy_grid", &guik::AsyncLightViewerContext::set_draw_xy_grid, "")
+    .def(
+      "use_orbit_camera_control",
+      &guik::AsyncLightViewerContext::use_orbit_camera_control,
+      "",
+      py::arg("distance") = 80.0,
+      py::arg("theta") = 0.0,
+      py::arg("phi") = -60.0 * M_PI / 180.0)
+    .def("use_orbit_camera_control_xz", &guik::AsyncLightViewerContext::use_orbit_camera_control_xz, "", py::arg("distance") = 80.0, py::arg("theta") = 0.0, py::arg("phi") = 0.0)
+    .def("use_topdown_camera_control", &guik::AsyncLightViewerContext::use_topdown_camera_control, "", py::arg("distance") = 80.0, py::arg("theta") = 0.0);
+
+  // AsyncLightViewer
+  py::class_<guik::AsyncLightViewer, std::unique_ptr<guik::AsyncLightViewer, py::nodelete>>(guik_, "AsyncLightViewer")
+    .def_static(
+      "instance",
+      [](const Eigen::Vector2i& size, bool background, const std::string& title) { return instance(size, background, title); },
+      py::arg("size") = Eigen::Vector2i(1920, 1080),
+      py::arg("background") = false,
+      py::arg("title") = "screen")
+    .def(
+      "async_sub_viewer",
+      [](guik::AsyncLightViewer& viewer, const std::string& name, const std::tuple<int, int>& size) {
+        return viewer.async_sub_viewer(name, Eigen::Vector2i(std::get<0>(size), std::get<1>(size)));
+      })
+
+    // LightViewerContext methods
+    .def("clear", &guik::AsyncLightViewer::clear)
+    .def("clear_text", &guik::AsyncLightViewer::clear_text)
+    .def("append_text", &guik::AsyncLightViewer::append_text, py::arg("text"))
+    .def("register_ui_callback", &guik::AsyncLightViewer::register_ui_callback, py::arg("callback_name"), py::arg("callback"))
+
+    .def(
+      "remove_drawable",
+      [](guik::AsyncLightViewer& context, const std::string& pattern, bool regex) {
+        if (regex) {
+          context.remove_drawable(std::regex(pattern));
+        } else {
+          context.remove_drawable(pattern);
+        }
+      },
+      py::arg("pattern"),
+      py::arg("regex") = false)
+    .def("reset_center", &guik::AsyncLightViewer::reset_center)
+    .def("lookat", &guik::AsyncLightViewer::lookat, py::arg("pt"))
+    .def("set_draw_xy_grid", &guik::AsyncLightViewer::set_draw_xy_grid, py::arg("enable"))
+    .def("use_orbit_camera_control", &guik::AsyncLightViewer::use_orbit_camera_control, py::arg("distance") = 80.0, py::arg("theta") = 0.0, py::arg("phi") = -60.0 * M_PI / 180.0)
+    .def("use_orbit_camera_control_xz", &guik::AsyncLightViewer::use_orbit_camera_control_xz, py::arg("distance") = 80.0, py::arg("theta") = 0.0, py::arg("phi") = 0.0)
+    .def("use_topdown_camera_control", &guik::AsyncLightViewer::use_topdown_camera_control, py::arg("distance") = 80.0, py::arg("theta") = 0.0);
+
   // guik::RecentFiles
   py::class_<guik::RecentFiles>(guik_, "RecentFiles")
     .def(py::init<const std::string&>())
@@ -286,4 +379,13 @@ void define_guik(py::module_& m) {
     py::arg("background") = false,
     py::arg("title") = "screen");
   guik_.def("destroy", &guik::destroy, "");
+  guik_.def(
+    "async_viewer",
+    [](const Eigen::Vector2i& size, bool background, const std::string& title) { return async_instance(size, background, title); },
+    "",
+    py::arg("size") = Eigen::Vector2i(1920, 1080),
+    py::arg("background") = false,
+    py::arg("title") = "screen");
+  guik_.def("async_destroy", &guik::async_destroy, "");
+  guik_.def("async_wait", &guik::async_wait, "");
 }


### PR DESCRIPTION
- Add `AsyncLightViewer` that enables keeping the viewer interactive while the main thread is doing some blocking operations.
- Make `guik::viewer` return a raw pointer instead of `shared_ptr` to avoid unnecessary reference count. I believe this change requires only a minimum or none modifications in the user side.
- Add plotting utilities
- Make  images ordered