### PR TITLE
png_io.cpp: fix libpng include

### DIFF
--- a/src/glk/io/png_io.cpp
+++ b/src/glk/io/png_io.cpp
@@ -1,7 +1,7 @@
 #include <glk/io/png_io.hpp>
 
 #include <iostream>
-#include <libpng/png.h>
+#include <png.h>
 #include <glk/console_colors.hpp>
 
 namespace glk {


### PR DESCRIPTION
libpng headers do not include a directory prefix. This only accidentally worked with system headers.