### PR TITLE
feat(glk): transparency feature enabled for drawable objects

### DIFF
--- a/src/glk/gridmap.cpp
+++ b/src/glk/gridmap.cpp
@@ -120,6 +120,11 @@ void GridMap::init_vao(double resolution, int width, int height) {
 }
 
 void GridMap::draw(glk::GLSLShader& shader) const {
+
+  glEnable(GL_BLEND);
+  glDepthMask(GL_FALSE);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
   glActiveTexture(GL_TEXTURE1);
   glBindTexture(GL_TEXTURE_2D, texture->id());
   glActiveTexture(GL_TEXTURE0);
@@ -143,6 +148,9 @@ void GridMap::draw(glk::GLSLShader& shader) const {
 
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   glBindVertexArray(0);
+
+  glDepthMask(GL_TRUE);
+  glDisable(GL_BLEND);
 
   // texture->unbind(GL_TEXTURE1);
 }

--- a/src/glk/indexed_pointcloud_buffer.cpp
+++ b/src/glk/indexed_pointcloud_buffer.cpp
@@ -22,6 +22,10 @@ IndexedPointCloudBuffer::~IndexedPointCloudBuffer() {
 }
 
 void IndexedPointCloudBuffer::draw(glk::GLSLShader& shader) const {
+  glEnable(GL_BLEND);
+  glDepthFunc(GL_FALSE);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
   cloud_buffer->bind(shader);
 
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);
@@ -29,6 +33,8 @@ void IndexedPointCloudBuffer::draw(glk::GLSLShader& shader) const {
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 
   cloud_buffer->unbind(shader);
+  glDepthMask(GL_TRUE);
+  glDisable(GL_BLEND);
 }
 
 GLuint IndexedPointCloudBuffer::ebo_id() const {

--- a/src/glk/lines.cpp
+++ b/src/glk/lines.cpp
@@ -141,6 +141,9 @@ void Lines::draw(glk::GLSLShader& shader) const {
   GLint position_loc = shader.attrib("vert_position");
   GLint color_loc = 0;
   GLint info_loc = 0;
+  glEnable(GL_BLEND);
+  glDepthMask(GL_FALSE);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
   glBindVertexArray(vao);
 
@@ -177,5 +180,8 @@ void Lines::draw(glk::GLSLShader& shader) const {
 
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   glBindVertexArray(0);
+
+  glDisable(GL_BLEND);
+  glDepthMask(GL_TRUE);
 }
 }  // namespace glk

--- a/src/glk/mesh.cpp
+++ b/src/glk/mesh.cpp
@@ -111,6 +111,10 @@ void Mesh::draw(glk::GLSLShader& shader) const {
   if (texture) {
     texture->bind(texture_target);
   }
+  
+  glEnable(GL_BLEND);
+  glDepthMask(GL_FALSE);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
   const bool cull_was_enabled = glIsEnabled(GL_CULL_FACE);
   if (wireframe) {
@@ -182,6 +186,9 @@ void Mesh::draw(glk::GLSLShader& shader) const {
   if (texture) {
     texture->unbind(texture_target);
   }
+
+  glDepthMask(GL_TRUE);
+  glDisable(GL_BLEND);
 }
 
 }  // namespace glk

--- a/src/glk/normal_distributions.cpp
+++ b/src/glk/normal_distributions.cpp
@@ -129,6 +129,12 @@ NormalDistributions::~NormalDistributions() {
 }
 
 void NormalDistributions::draw(glk::GLSLShader& shader) const {
+
+  glEnable(GL_BLEND);
+  glDepthMask(GL_FALSE);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+
   glBindVertexArray(vao);
 
   GLint position_loc = shader.attrib("vert_position");
@@ -144,6 +150,9 @@ void NormalDistributions::draw(glk::GLSLShader& shader) const {
 
   glBindBuffer(GL_ARRAY_BUFFER, 0);
   glBindVertexArray(0);
+
+  glDepthMask(GL_TRUE);
+  glDisable(GL_BLEND);
 }
 
 template <typename T, int D>

--- a/src/glk/pointcloud_buffer.cpp
+++ b/src/glk/pointcloud_buffer.cpp
@@ -310,6 +310,9 @@ void PointCloudBuffer::draw(glk::GLSLShader& shader) const {
   if (num_points == 0) {
     return;
   }
+  glEnable(GL_BLEND);
+  glDepthFunc(GL_FALSE);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
   bind(shader);
 
@@ -325,6 +328,10 @@ void PointCloudBuffer::draw(glk::GLSLShader& shader) const {
   }
 
   unbind(shader);
+
+  glDepthMask(GL_TRUE);
+  glDisable(GL_BLEND);
+
 }
 
 GLuint PointCloudBuffer::vba_id() const {

--- a/src/glk/thin_lines.cpp
+++ b/src/glk/thin_lines.cpp
@@ -61,6 +61,10 @@ void ThinLines::draw(glk::GLSLShader& shader) const {
   GLint position_loc = shader.attrib("vert_position");
   GLint color_loc = shader.attrib("vert_color");
 
+  glEnable(GL_BLEND);
+  glDepthFunc(GL_FALSE);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
   glLineWidth(line_width);
 
   glBindVertexArray(vao);
@@ -93,5 +97,8 @@ void ThinLines::draw(glk::GLSLShader& shader) const {
   glBindVertexArray(0);
 
   glLineWidth(1.0);
+
+  glDepthFunc(GL_TRUE);
+  glDisable(GL_BLEND);
 }
 }  // namespace glk

--- a/src/glk/transform_feedback.cpp
+++ b/src/glk/transform_feedback.cpp
@@ -40,11 +40,18 @@ void TransformFeedback::read_data(intptr_t offset, size_t size, void* data) {
 
 void TransformFeedback::draw(glk::GLSLShader& shader) const {
   GLint position_loc = shader.attrib("vert_position");
+  glEnable(GL_BLEND);
+  glDepthFunc(GL_FALSE);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
   glBindBuffer(GL_ARRAY_BUFFER, tbo);
   glEnableVertexAttribArray(position_loc);
   glVertexAttribPointer(position_loc, 3, GL_FLOAT, GL_FALSE, sizeof(float) * 3, 0);
 
   glDrawTransformFeedback(GL_POINTS, feedback);
+
+  glDisable(GL_BLEND);
+  glDepthFunc(GL_TRUE);
 }
 
 }  // namespace glk


### PR DESCRIPTION
Alpha values doesn't work when I try to set it, the updates offer to changeable opacity value for any drawable object. The following gift shows that the point cloud and normal distribution objects' transparency settable.

![transparency_enabled](https://github.com/koide3/iridescence/assets/73120336/d3b076d0-49df-4098-a66c-dfc74c61666d)
