### PR TITLE
Fixed set_pose in fps camera control

### DIFF
--- a/src/guik/camera/fps_camera_control.cpp
+++ b/src/guik/camera/fps_camera_control.cpp
@@ -78,8 +78,8 @@ Eigen::Matrix4f FPSCameraControl::projection_matrix() const {
 
 void FPSCameraControl::set_pose(const Eigen::Vector3f& pos, double yaw_deg, double pitch_deg) {
   this->pos = pos;
-  this->yaw = yaw * M_PI / 180.0;
-  this->pitch = pitch * M_PI / 180.0;
+  this->yaw = yaw_deg * M_PI / 180.0;
+  this->pitch = pitch_deg * M_PI / 180.0;
 }
 
 void FPSCameraControl::reset_center() {}


### PR DESCRIPTION
Hi, I found a small bug in `set_pose` function of FPS camera control. I tested it and now setting pitch and yaw works with my fix. Would be very appreciated if you could take a look.