### PR TITLE
[update] Add definition of 'frustum/wire_frustum' in Python API

### DIFF
--- a/src/python/glk.cpp
+++ b/src/python/glk.cpp
@@ -333,9 +333,11 @@ void define_glk(py::module_& m) {
   primitives_.def("icosahedron", [] { return glk::Primitives::icosahedron(); });
   primitives_.def("bunny", [] { return glk::Primitives::bunny(); });
   primitives_.def("coordinate_system", [] { return glk::Primitives::coordinate_system(); });
+  primitives_.def("frustum", [] { return glk::Primitives::frustum(); });
   primitives_.def("wire_sphere", [] { return glk::Primitives::wire_sphere(); });
   primitives_.def("wire_cube", [] { return glk::Primitives::wire_cube(); });
   primitives_.def("wire_cone", [] { return glk::Primitives::wire_cone(); });
   primitives_.def("wire_icosahedron", [] { return glk::Primitives::wire_icosahedron(); });
   primitives_.def("wire_bunny", [] { return glk::Primitives::wire_bunny(); });
+  primitives_.def("wire_frustum", [] { return glk::Primitives::wire_frustum(); });
 }


### PR DESCRIPTION
Thank you for the great work.

I've found that `frustum` and `wire_frustum` are not found in Python API.
So I fixed `src/python/glk.cpp` to include those primitives.