### PR TITLE
look for data at install location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/iridescence CACHE PATH "Loca
 
 # imgui
 add_definitions(-DIMGUI_IMPL_OPENGL_LOADER_GL3W)
+add_definitions(-DDATA_INSTALL_PATH="${CMAKE_INSTALL_FULL_DATADIR}/iridescence/data")
 add_definitions(-DDATA_PATH_GUESS="${CMAKE_SOURCE_DIR}/data")
 
 if(MSVC)

--- a/src/glk/path_std.cpp
+++ b/src/glk/path_std.cpp
@@ -51,6 +51,9 @@ std::string get_data_path() {
     std::vector<std::string> hints;
     hints.push_back("./data");
     hints.push_back("../data");
+#ifdef DATA_INSTALL_PATH
+    hints.push_back(DATA_INSTALL_PATH);
+#endif
     hints.push_back("/usr/share/iridescence");
     hints.push_back("/usr/local/share/iridescence");
 #ifdef DATA_PATH_GUESS


### PR DESCRIPTION
When the package is installed at a non-standard location, i.e. with prefix different from `/usr` or `/usr/local`, the data directory cannot be found. This change ensures that the install location is always tried when looking for the data directory.