### PR TITLE
fix(glk): delete GridMap VAO with glDeleteVertexArrays

### DIFF
--- a/src/glk/gridmap.cpp
+++ b/src/glk/gridmap.cpp
@@ -95,7 +95,7 @@ void GridMap::update_color(int width, int height, float scale, const float* valu
 }
 
 GridMap::~GridMap() {
-  glDeleteBuffers(1, &vao);
+  glDeleteVertexArrays(1, &vao);
   glDeleteBuffers(1, &vbo);
   glDeleteBuffers(1, &tbo);
 }


### PR DESCRIPTION
This may result in the new drawable with the same name being unable to be rendered correctly.